### PR TITLE
Fix Docker run by updating Dash server call

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,4 +71,6 @@ def run_calculation(n_clicks, consumption_contents, address, region, pv_size):
 
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    # Dash >=2.0 deprecates ``run_server`` in favor of ``run``.
+    # Bind to all interfaces so the app works inside Docker.
+    app.run(debug=True, host="0.0.0.0")


### PR DESCRIPTION
## Summary
- use `app.run` instead of the deprecated `run_server`
- listen on `0.0.0.0` so Docker exposes the app

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684696884aec832498fd7ed2788aebd3