### PR TITLE
Add periodic DMI data fetcher

### DIFF
--- a/modules/dmi_weather.py
+++ b/modules/dmi_weather.py
@@ -1,0 +1,74 @@
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://dmigw.govcloud.dk/v2/metObs/collections/observation/items"
+DMI_TOKEN = "<INSERT API TOKEN>"  # obtain from https://confluence.govcloud.dk/
+CACHE_DIR = Path("cache")
+CACHE_DIR.mkdir(exist_ok=True)
+
+
+def _cache_path(station_id: str, start: datetime, end: datetime) -> Path:
+    """Return file path for cached data."""
+    name = f"{station_id}_{start:%Y%m%d}_{end:%Y%m%d}.json"
+    return CACHE_DIR / name
+
+
+def fetch_observations(
+    station_id: str,
+    start: datetime,
+    end: datetime,
+) -> Optional[pd.DataFrame]:
+    """Download DMI observations if not cached and return as dataframe."""
+    cache_file = _cache_path(station_id, start, end)
+    if cache_file.exists():
+        try:
+            with cache_file.open() as fh:
+                records = json.load(fh)
+            logger.info("Loaded cached DMI data %s", cache_file)
+            return pd.json_normalize(records)
+        except Exception as exc:
+            logger.warning("Failed reading cache %s: %s", cache_file, exc)
+
+    params = {
+        "api-key": DMI_TOKEN,
+        "limit": 100000,
+        "stationId": station_id,
+        "datetime": f"{start.isoformat()}Z/{end.isoformat()}Z",
+    }
+    try:
+        resp = requests.get(BASE_URL, params=params, timeout=20)
+        resp.raise_for_status()
+        records = resp.json()["features"]
+    except Exception as exc:
+        logger.error("Downloading DMI observations failed: %s", exc)
+        return None
+
+    with cache_file.open("w") as fh:
+        json.dump(records, fh)
+
+    return pd.json_normalize(records)
+
+
+def start_periodic_fetch(station_id: str, interval_hours: int = 24) -> threading.Thread:
+    """Start background thread to fetch observations periodically."""
+
+    def _worker() -> None:
+        while True:
+            end = datetime.utcnow()
+            start = end - timedelta(hours=interval_hours)
+            fetch_observations(station_id, start, end)
+            time.sleep(interval_hours * 3600)
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    return thread

--- a/tests/test_dmi_weather.py
+++ b/tests/test_dmi_weather.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+import json
+from unittest import mock
+
+from modules import dmi_weather
+
+
+def test_fetch_from_cache(tmp_path):
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 2)
+    cache_dir = tmp_path
+    cache_file = cache_dir / "06180_20240101_20240102.json"
+    cache_dir.mkdir(exist_ok=True)
+    cache_file.write_text(json.dumps([{"a": 1}]))
+
+    with mock.patch("modules.dmi_weather.CACHE_DIR", cache_dir), \
+         mock.patch("modules.dmi_weather.requests.get") as req:
+        df = dmi_weather.fetch_observations("06180", start, end)
+        assert req.call_count == 0
+        assert len(df) == 1
+
+
+def test_fetch_downloads_and_caches(tmp_path):
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 2)
+    cache_dir = tmp_path
+    cache_dir.mkdir(exist_ok=True)
+    resp = mock.Mock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"features": [{"a": 1}]}
+
+    with mock.patch("modules.dmi_weather.CACHE_DIR", cache_dir), \
+         mock.patch("modules.dmi_weather.requests.get", return_value=resp) as req:
+        df = dmi_weather.fetch_observations("06180", start, end)
+        assert req.call_count == 1
+        cache_file = cache_dir / "06180_20240101_20240102.json"
+        assert cache_file.exists()
+        assert len(df) == 1


### PR DESCRIPTION
## Summary
- implement `dmi_weather` module to retrieve and cache DMI observation data
- add periodic background thread for daily updates
- test caching logic for DMI weather module

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68469ae88a688324b39868ed7010af80