### PR TITLE
Add python-dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ grafer over produktion og økonomisk besparelse.
    ```bash
    pip install -r requirements.txt
    ```
+   Opret eventuelt en `.env`-fil med API-nøgler:
+   ```bash
+   echo "DMI_TOKEN=din_token" > .env
+   ```
 2. Start applikationen:
    ```bash
    python app.py

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,7 @@
+"""Utility initialisation for modules package."""
+
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present.
+load_dotenv()
+

--- a/modules/dmi_weather.py
+++ b/modules/dmi_weather.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import threading
 import time
 from datetime import datetime, timedelta
@@ -12,7 +13,8 @@ import requests
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://dmigw.govcloud.dk/v2/metObs/collections/observation/items"
-DMI_TOKEN = "<INSERT API TOKEN>"  # obtain from https://confluence.govcloud.dk/
+# Token can be provided via a .env file or environment variable
+DMI_TOKEN = os.getenv("DMI_TOKEN", "")
 CACHE_DIR = Path("cache")
 CACHE_DIR.mkdir(exist_ok=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 pvlib
 requests
 dash-bootstrap-components
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables via python-dotenv when importing `modules`
- read DMI token from environment
- add `python-dotenv` to dependencies
- document `.env` usage

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469dd06a048324bb7ab99b7deaaeae