### PR TITLE
Add info log for DMI network fetch

### DIFF
--- a/modules/dmi_weather.py
+++ b/modules/dmi_weather.py
@@ -47,6 +47,12 @@ def fetch_observations(
         "stationId": station_id,
         "datetime": f"{start.isoformat()}Z/{end.isoformat()}Z",
     }
+    logger.info(
+        "Fetching DMI observations for %s from %s to %s",
+        station_id,
+        start.isoformat(),
+        end.isoformat(),
+    )
     try:
         resp = requests.get(BASE_URL, params=params, timeout=20)
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
- log when downloading observations from DMI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a12c45848324b0df97d1864d04d5