### PR TITLE
Implement DMI-based solar simulation

### DIFF
--- a/modules/pvlib_calc.py
+++ b/modules/pvlib_calc.py
@@ -29,3 +29,20 @@ def estimate_production(lat: float, lon: float, pv_size_kwp: float,
     except Exception as exc:
         logger.exception("PVlib estimation failed: %s", exc)
         return None
+
+
+def estimate_production_with_irradiance(
+    ghi: pd.Series,
+    pv_size_kwp: float,
+) -> Optional[pd.Series]:
+    """Estimate PV production from GHI using a simple linear model."""
+    if ghi is None or ghi.empty:
+        return None
+    try:
+        ghi = ghi.resample("1h").mean()
+        production = pv_size_kwp * (ghi / 1000.0)
+        production.index = production.index.tz_localize(None)
+        return production
+    except Exception as exc:  # pragma: no cover - rare failure
+        logger.exception("PVlib irradiance estimation failed: %s", exc)
+        return None

--- a/tests/test_dmi_weather.py
+++ b/tests/test_dmi_weather.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import json
 from unittest import mock
 
+import pandas as pd
 from modules import dmi_weather
 
 
@@ -36,3 +37,17 @@ def test_fetch_downloads_and_caches(tmp_path):
         cache_file = cache_dir / "06180_20240101_20240102.json"
         assert cache_file.exists()
         assert len(df) == 1
+
+
+def test_get_hourly_global_radiation():
+    df = pd.DataFrame({
+        "properties.parameterId": ["globalRadiation", "globalRadiation"],
+        "properties.observed": ["2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z"],
+        "properties.value": [100, 200],
+    })
+    with mock.patch("modules.dmi_weather.fetch_observations", return_value=df):
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 1, 1)
+        rad = dmi_weather.get_hourly_global_radiation("06180", start, end)
+        assert rad is not None
+        assert list(rad.values) == [100, 200]

--- a/tests/test_pvlib_calc.py
+++ b/tests/test_pvlib_calc.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import pandas as pd
 from modules import pvlib_calc
 
 
@@ -8,3 +9,10 @@ def test_estimate_production():
     result = pvlib_calc.estimate_production(55.0, 10.0, 5, start, end)
     assert result is not None
     assert len(result) == 3
+
+
+def test_estimate_production_with_irradiance():
+    ghi = pd.Series([100, 200], index=[datetime(2024, 1, 1), datetime(2024, 1, 1, 1)])
+    result = pvlib_calc.estimate_production_with_irradiance(ghi, 5)
+    assert result is not None
+    assert len(result) == 2


### PR DESCRIPTION
## Summary
- allow selecting a date range for solar simulation
- fetch hourly global radiation from DMI observations
- calculate PV output from provided irradiance
- plot the simulated PV production
- test new DMI and pvlib features

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a2608dfc832484f28318f95843c9