### PR TITLE
Fix callback ID mismatch by adding DatePickerRange

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,13 @@ app.layout = dbc.Container(
                     placeholder="Hældning (grader)",
                     className="mb-2",
                 ),
+                dcc.DatePickerRange(
+                    id="date-range",
+                    start_date_placeholder_text="Start dato",
+                    end_date_placeholder_text="Slut dato",
+                    display_format="YYYY-MM-DD",
+                    className="mb-2",
+                ),
                 dbc.Button("Beregn", id="calculate", color="success", className="mb-4"),
                 html.H4("Simulator data", className="mt-4"),
                 dcc.DatePickerSingle(id="sim-start", className="mb-2"),


### PR DESCRIPTION
## Summary
- add missing DatePickerRange component so callback states exist

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b3482c048324a2d06218a10ade0b