### PR TITLE
Fix dash callback cycle

### DIFF
--- a/app.py
+++ b/app.py
@@ -200,9 +200,10 @@ def save_inputs(address, region, start_date, end_date, current):
     Output("region", "value"),
     Output("date-range", "start_date"),
     Output("date-range", "end_date"),
-    Input("input-store", "data"),
+    Input("input-store", "modified_timestamp"),
+    State("input-store", "data"),
 )
-def load_inputs(data):
+def load_inputs(ts, data):  # noqa: ARG001
     if not data:
         return (
             dash.no_update,


### PR DESCRIPTION
## Summary
- fix input persistence by avoiding dash callback cycle

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ce8a76e88324b0c89e6f6d538d48