### PR TITLE
Fix DMI fetch when start date is after end date

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,6 +104,7 @@ app.layout = dbc.Container(
                         id="date-range",
                         start_date="2024-01-01",
                         end_date="2024-12-31",
+                        max_date_allowed=datetime.utcnow().date(),
                         start_date_placeholder_text="Start dato",
                         end_date_placeholder_text="Slut dato",
                         display_format="YYYY-MM-DD",

--- a/modules/dmi_weather.py
+++ b/modules/dmi_weather.py
@@ -30,7 +30,14 @@ def fetch_observations(
     start: datetime,
     end: datetime,
 ) -> Optional[pd.DataFrame]:
-    """Download DMI observations if not cached and return as dataframe."""
+    """Download DMI observations if not cached and return as dataframe.
+
+    ``start`` and ``end`` may be provided in any order; if ``start`` is later
+    than ``end`` they are swapped before requesting data.
+    """
+    if start > end:
+        start, end = end, start
+
     cache_file = _cache_path(station_id, start, end)
     if cache_file.exists():
         try:

--- a/tests/test_dmi_weather.py
+++ b/tests/test_dmi_weather.py
@@ -39,6 +39,23 @@ def test_fetch_downloads_and_caches(tmp_path):
         assert len(df) == 1
 
 
+def test_fetch_swaps_reversed_dates(tmp_path):
+    start = datetime(2024, 1, 2)
+    end = datetime(2024, 1, 1)
+    cache_dir = tmp_path
+    cache_dir.mkdir(exist_ok=True)
+    resp = mock.Mock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"features": []}
+
+    with mock.patch("modules.dmi_weather.CACHE_DIR", cache_dir), \
+         mock.patch("modules.dmi_weather.requests.get", return_value=resp) as req:
+        dmi_weather.fetch_observations("06180", start, end)
+        assert req.call_count == 1
+        params = req.call_args[1]["params"]
+        assert params["datetime"] == "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z"
+
+
 def test_get_hourly_global_radiation():
     df = pd.DataFrame({
         "properties.parameterId": ["globalRadiation", "globalRadiation"],


### PR DESCRIPTION
## Summary
- handle reversed start/end dates when fetching DMI observations
- test the new behaviour
- disable selecting future dates in the date picker

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d132347c8324bc3579f024446c2a