### PR TITLE
Add host-mapped cache for weather data

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ kører containeren:
 docker-compose up --build
 ```
 Herefter kører Dash serveren på `http://127.0.0.1:8050/`.
+
+Docker-compose mapper mappen `./cache` fra værtsmaskinen til `/app/cache` i
+containeren. Alle downloaded data gemmes derfor i `./cache`, hvilket bevarer
+cachen mellem genstart af containeren. Stien kan ændres ved at sætte
+miljøvariablen `CACHE_DIR`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,7 @@ services:
     ports:
       - "8050:8050"
     command: python app.py
+    volumes:
+      - ./cache:/app/cache
+    environment:
+      - CACHE_DIR=/app/cache

--- a/modules/dmi_weather.py
+++ b/modules/dmi_weather.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://dmigw.govcloud.dk/v2/metObs/collections/observation/items"
 # Token can be provided via a .env file or environment variable
 DMI_TOKEN = os.getenv("DMI_TOKEN", "")
-CACHE_DIR = Path("cache")
+# Allow overriding the cache directory through an environment variable.
+CACHE_DIR = Path(os.getenv("CACHE_DIR", "cache"))
 CACHE_DIR.mkdir(exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- allow overriding the cache directory with `CACHE_DIR`
- mount the `cache` directory to the host in `docker-compose`
- document caching in README

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846d6ec24948324b4978683cf64e482