### PR TITLE
perf: cache PVGIS responses and static assets to reduce Fast Origin Transfer

### DIFF
--- a/api/pvgis/[...path].mjs
+++ b/api/pvgis/[...path].mjs
@@ -9,5 +9,9 @@ export default async function handler(req, res) {
   const body = await upstreamRes.text()
   const contentType = upstreamRes.headers.get('content-type')
   if (contentType) res.setHeader('Content-Type', contentType)
+  if (upstreamRes.status === 200) {
+    // PVGIS returns historical climate data — immutable for a given location/config
+    res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=604800')
+  }
   res.status(upstreamRes.status).send(body)
 }

--- a/src/components/PrivacyPage.tsx
+++ b/src/components/PrivacyPage.tsx
@@ -21,7 +21,7 @@ const SERVICES = [
     domain: 're.jrc.ec.europa.eu',
     sends: 'Koordinater + anlægsdata',
     receives: 'Timebaseret solproduktion',
-    note: 'Anmodningen går via en Vercel-proxy-funktion for at omgå browser-CORS-begrænsninger.',
+    note: 'Anmodningen går via en Vercel-proxy-funktion for at omgå browser-CORS-begrænsninger. Svaret caches i Vercels CDN i op til 7 dage, nøglet på koordinater og anlægsparametre — ingen persondata.',
     optional: false,
     via: 'proxy',
   },
@@ -87,7 +87,7 @@ export function PrivacyPage({ onBack }: Props) {
           Privatliv & datasikkerhed
         </h1>
         <p className="text-muted-foreground text-base leading-relaxed">
-          Er du sunshine? er bygget på et enkelt princip: al beregning sker i din browser. Sitet hostes på Vercel og bruger to proxy-funktioner til at videresende API-kald — ingen data behandles eller gemmes på serversiden. Nedenfor kan du se præcist, hvilke eksterne tjenester din browser taler med — og hvad der sendes.
+          Er du sunshine? er bygget på et enkelt princip: al beregning sker i din browser. Sitet hostes på Vercel og bruger to proxy-funktioner til at videresende API-kald. PVGIS-svar caches kortvarigt i Vercels CDN (op til 7 dage) for at reducere belastningen — ingen persondata gemmes. Nedenfor kan du se præcist, hvilke eksterne tjenester din browser taler med — og hvad der sendes.
         </p>
       </div>
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,18 @@
 {
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/api/eloverblik/:path+", "destination": "/api/eloverblik/[...path]" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }


### PR DESCRIPTION
## Summary
- Add `s-maxage=86400` + `stale-while-revalidate=604800` to PVGIS proxy so Vercel's edge CDN caches responses — PVGIS returns historical climate data that never changes for a given location/config
- Add `immutable` cache headers for hashed `/assets/*` bundles and `no-cache` for `index.html` in `vercel.json`
- Update privacy page to disclose that PVGIS responses are cached at Vercel's CDN edge for up to 7 days

## Test plan
- [ ] Verify PVGIS data still loads correctly
- [ ] Verify second request for same location is served from CDN (check response headers for `x-vercel-cache: HIT`)
- [ ] Verify privacy page reflects caching disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)