### PR TITLE
fix: prevent infinite re-simulation loop when results update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,10 @@ export default function App() {
     }
   }, [coordinates, simulationResult])
 
+  // Track simulationResult in a ref so we can guard without it being a reactive dependency
+  const simulationResultRef = useRef(simulationResult)
+  simulationResultRef.current = simulationResult
+
   // Auto re-simulate when solar/battery/addon config changes while results exist
   const isInitialMount = useRef(true)
   useEffect(() => {
@@ -55,10 +59,10 @@ export default function App() {
       isInitialMount.current = false
       return
     }
-    if (!simulationResult) return
+    if (!simulationResultRef.current) return
     const timer = setTimeout(() => { runSimulationRef.current() }, 700)
     return () => clearTimeout(timer)
-  }, [solarConfig, batteryConfig, heatpumpEnabled, evKmPerDay, existingSolarConfig, simulationResult])
+  }, [solarConfig, batteryConfig, heatpumpEnabled, evKmPerDay, existingSolarConfig])
 
   // Privacy / Methodology overlays (full-page, same shell)
   if (overlay === 'privacy') {


### PR DESCRIPTION
Closes #70

## Summary
- `simulationResult` was listed as a `useEffect` dependency in the auto-re-simulate effect
- Every completed simulation updated `simulationResult`, which re-triggered the effect, scheduling another simulation after 700ms — an infinite loop
- Fix: move `simulationResult` to a ref so it can be checked without being reactive

## Test plan
- [ ] Run the simulation once — it should complete and stay idle
- [ ] Change a solar config value — it should re-simulate exactly once, then stop
- [ ] All 140 unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)