### PR TITLE
Multi-segment roof support (east/west split roofs)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,7 +206,7 @@ export default function App() {
                     <AddressMap
                       coordinates={coordinates}
                       displayName={address}
-                      azimuthDeg={solarConfig.azimuthDeg}
+                      azimuthDeg={solarConfig.segments[0]?.azimuthDeg}
                     />
                   </div>
                 )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,7 +206,7 @@ export default function App() {
                     <AddressMap
                       coordinates={coordinates}
                       displayName={address}
-                      azimuthDeg={solarConfig.segments[0]?.azimuthDeg}
+                      azimuthDegs={solarConfig.segments.map((s) => s.azimuthDeg)}
                     />
                   </div>
                 )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -214,7 +214,7 @@ export default function App() {
                   label={(consumption.hasExport || existingSolarConfig) ? 'Simuleret udvidelse' : undefined}
                   advanced={advanced}
                 />
-                {(consumption.hasExport || existingSolarConfig) && <ExistingSolarForm advanced={advanced} />}
+                {(consumption.hasExport || existingSolarConfig) && <ExistingSolarForm />}
                 <ConsumptionAddonsForm />
                 <BatteryConfigForm advanced={advanced} />
                 <PricingForm />

--- a/src/components/MethodologyPage.tsx
+++ b/src/components/MethodologyPage.tsx
@@ -169,7 +169,7 @@ export function MethodologyPage({ onBack }: Props) {
             <div className="font-medium text-foreground">Parametre vi sender</div>
             <ul className="space-y-1 text-muted-foreground leading-relaxed">
               <li><span className="text-orange-500 font-medium">→</span> Latitude/longitude</li>
-              <li><span className="text-orange-500 font-medium">→</span> Toppeffekt (kWp)</li>
+              <li><span className="text-orange-500 font-medium">→</span> Toppeffekt (kWp) — pr. tag-flade</li>
               <li><span className="text-orange-500 font-medium">→</span> Hælding (0–90°)</li>
               <li><span className="text-orange-500 font-medium">→</span> Azimut (-180° til 180°)</li>
               <li><span className="text-orange-500 font-medium">→</span> Systemtab (%)</li>
@@ -191,6 +191,39 @@ export function MethodologyPage({ onBack }: Props) {
         <Formula lines={[
           'produktion[h] = P[h] / 1000',
           '// W gennemsnit pr. time → kWh pr. time',
+        ]} />
+
+        <div className="rounded-lg bg-muted/50 border border-border p-3 text-xs text-muted-foreground space-y-1">
+          <div className="font-medium text-foreground">Flere tag-flader</div>
+          <div>
+            Et anlæg kan bestå af op til 3 tag-flader med hver sin hælding og retning — fx en øst- og en vestvendt side. PVGIS kaldes én gang pr. tag-flade, og de resulterende timeserier for produktion lægges sammen time for time, før de indgår i simuleringen.
+          </div>
+        </div>
+        <Formula lines={[
+          'produktionTotal[h] = Σ tagflade.P[h] / 1000   // summeret på tværs af tag-flader',
+        ]} />
+
+        <p className="text-sm text-muted-foreground">
+          Toppeffekten (kWp) for hver tag-flade kan angives på to måder:
+        </p>
+        <div className="grid sm:grid-cols-2 gap-3 text-xs">
+          <div className="rounded-lg border border-border bg-card p-3 space-y-2">
+            <div className="font-medium text-foreground">Direkte (kWp)</div>
+            <p className="text-muted-foreground leading-relaxed">
+              Du angiver den installerede effekt direkte — typisk fra et konkret tilbud eller en eksisterende installation.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-card p-3 space-y-2">
+            <div className="font-medium text-foreground">Ud fra tagmål</div>
+            <p className="text-muted-foreground leading-relaxed">
+              Du angiver tagfladens bredde og længde samt panelspecifikationer (effekt og fysiske mål — standard 440 Wp / 1,13 × 2,28 m). Effekten udregnes som et groft estimat ud fra, hvor mange paneler der kan være på arealet.
+            </p>
+          </div>
+        </div>
+        <Formula lines={[
+          'nyttigAreal = tagbredde × taglængde × 0,85       // 85 % — plads til montering, kanter, skorstene mv.',
+          'panelAntal  = ⌊ nyttigAreal / (panelbredde × panellængde) ⌋',
+          'toppeffekt  = panelAntal × paneleffekt / 1000    // Wp → kWp',
         ]} />
       </Section>
 

--- a/src/components/MethodologyPage.tsx
+++ b/src/components/MethodologyPage.tsx
@@ -169,7 +169,7 @@ export function MethodologyPage({ onBack }: Props) {
             <div className="font-medium text-foreground">Parametre vi sender</div>
             <ul className="space-y-1 text-muted-foreground leading-relaxed">
               <li><span className="text-orange-500 font-medium">→</span> Latitude/longitude</li>
-              <li><span className="text-orange-500 font-medium">→</span> Toppeffekt (kWp) — pr. tag-flade</li>
+              <li><span className="text-orange-500 font-medium">→</span> Installeret effekt (kWp) — pr. tag-flade</li>
               <li><span className="text-orange-500 font-medium">→</span> Hælding (0–90°)</li>
               <li><span className="text-orange-500 font-medium">→</span> Azimut (-180° til 180°)</li>
               <li><span className="text-orange-500 font-medium">→</span> Systemtab (%)</li>
@@ -204,7 +204,7 @@ export function MethodologyPage({ onBack }: Props) {
         ]} />
 
         <p className="text-sm text-muted-foreground">
-          Toppeffekten (kWp) for hver tag-flade kan angives på to måder:
+          Installeret effekt (kWp) for hver tag-flade kan angives på to måder:
         </p>
         <div className="grid sm:grid-cols-2 gap-3 text-xs">
           <div className="rounded-lg border border-border bg-card p-3 space-y-2">
@@ -221,9 +221,9 @@ export function MethodologyPage({ onBack }: Props) {
           </div>
         </div>
         <Formula lines={[
-          'nyttigAreal = tagbredde × taglængde × 0,85       // 85 % — plads til montering, kanter, skorstene mv.',
-          'panelAntal  = ⌊ nyttigAreal / (panelbredde × panellængde) ⌋',
-          'toppeffekt  = panelAntal × paneleffekt / 1000    // Wp → kWp',
+          'nyttigAreal        = tagbredde × taglængde × 0,85       // 85 % — plads til montering, kanter, skorstene mv.',
+          'panelAntal         = ⌊ nyttigAreal / (panelbredde × panellængde) ⌋',
+          'installeretEffekt  = panelAntal × paneleffekt / 1000    // Wp → kWp',
         ]} />
       </Section>
 

--- a/src/components/forms/AddressForm.tsx
+++ b/src/components/forms/AddressForm.tsx
@@ -88,7 +88,7 @@ export function AddressForm() {
           <AddressMap
             coordinates={coordinates}
             displayName={matchedName}
-            azimuthDeg={solarConfig.azimuthDeg}
+            azimuthDeg={solarConfig.segments[0]?.azimuthDeg}
           />
         </>
       )}

--- a/src/components/forms/AddressForm.tsx
+++ b/src/components/forms/AddressForm.tsx
@@ -88,7 +88,7 @@ export function AddressForm() {
           <AddressMap
             coordinates={coordinates}
             displayName={matchedName}
-            azimuthDeg={solarConfig.segments[0]?.azimuthDeg}
+            azimuthDegs={solarConfig.segments.map((s) => s.azimuthDeg)}
           />
         </>
       )}

--- a/src/components/forms/ExistingSolarForm.tsx
+++ b/src/components/forms/ExistingSolarForm.tsx
@@ -3,7 +3,7 @@ import { useAppStore, defaultExistingSolarConfig, MAX_SEGMENTS } from '@/store/a
 import { getSegmentPeakKw } from '@/lib/roofCapacity'
 import { RoofSegmentCard } from './RoofSegmentCard'
 
-export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) {
+export function ExistingSolarForm() {
   const existingSolarConfig    = useAppStore((s) => s.existingSolarConfig)
   const setExistingSolarConfig = useAppStore((s) => s.setExistingSolarConfig)
   const addExistingSegment     = useAppStore((s) => s.addExistingSegment)
@@ -85,7 +85,6 @@ export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) 
               <div key={segment.id} className={i > 0 ? 'pt-4' : undefined}>
                 <RoofSegmentCard
                   segment={segment}
-                  showOrientation={advanced || segments.length > 1}
                   title={segments.length > 1 ? `Tag-flade ${i + 1}` : undefined}
                   peakKwMin={0.5}
                   peakKwMax={30}

--- a/src/components/forms/ExistingSolarForm.tsx
+++ b/src/components/forms/ExistingSolarForm.tsx
@@ -1,17 +1,30 @@
 import { Sun } from 'lucide-react'
-import { useAppStore, defaultExistingSolarConfig } from '@/store/appStore'
+import { useAppStore, defaultExistingSolarConfig, MAX_SEGMENTS } from '@/store/appStore'
+import { getSegmentPeakKw } from '@/lib/roofCapacity'
+import { RoofSegmentCard } from './RoofSegmentCard'
 
 export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) {
   const existingSolarConfig    = useAppStore((s) => s.existingSolarConfig)
   const setExistingSolarConfig = useAppStore((s) => s.setExistingSolarConfig)
+  const addExistingSegment     = useAppStore((s) => s.addExistingSegment)
+  const removeExistingSegment  = useAppStore((s) => s.removeExistingSegment)
   const updateExistingSegment  = useAppStore((s) => s.updateExistingSegment)
 
   const enabled = existingSolarConfig !== null
   const config  = existingSolarConfig ?? defaultExistingSolarConfig()
-  const segment = config.segments[0]
+  const segments = config.segments
+  const totalKw = segments.reduce((sum, seg) => sum + getSegmentPeakKw(seg), 0)
 
   const toggle = () => setExistingSolarConfig(enabled ? null : defaultExistingSolarConfig())
-  const update = (partial: Partial<typeof segment>) => updateExistingSegment(segment.id, partial)
+
+  const setSegmentCount = (target: number) => {
+    const current = segments.length
+    if (target > current) {
+      for (let i = current; i < target; i++) addExistingSegment()
+    } else if (target < current) {
+      segments.slice(target).forEach((seg) => removeExistingSegment(seg.id))
+    }
+  }
 
   return (
     <div className="rounded-xl border border-amber-200 bg-amber-50/50 card-shadow p-5 space-y-4">
@@ -44,59 +57,44 @@ export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) 
 
       {enabled && (
         <>
-          <div className="space-y-1">
-            <div className="flex justify-between text-sm">
-              <label className="font-medium">Installeret effekt</label>
-              <span className="text-muted-foreground">{segment.peakKw} kWp</span>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-amber-700">Antal tag-flader</span>
+            <div className="flex rounded-lg border border-amber-200 bg-amber-100/50 p-0.5 text-sm">
+              {Array.from({ length: MAX_SEGMENTS }, (_, i) => i + 1).map((n) => (
+                <button
+                  key={n}
+                  onClick={() => setSegmentCount(n)}
+                  className={`rounded-md px-2.5 py-1 font-medium transition-colors ${
+                    segments.length === n ? 'bg-card shadow-sm text-amber-900' : 'text-amber-700 hover:text-amber-900'
+                  }`}
+                >
+                  {n}
+                </button>
+              ))}
             </div>
-            <input
-              type="range"
-              min={0.5}
-              max={30}
-              step={0.5}
-              value={segment.peakKw}
-              onChange={(e) => update({ peakKw: parseFloat(e.target.value) })}
-              className="w-full accent-primary"
-            />
-            <p className="text-xs text-muted-foreground">Dit nuværende anlægs toppeffekt</p>
           </div>
 
-          {advanced && (
-            <>
-              <div className="space-y-1">
-                <div className="flex justify-between text-sm">
-                  <label className="font-medium">Hældning</label>
-                  <span className="text-muted-foreground">{segment.tiltDeg}°</span>
-                </div>
-                <input
-                  type="range"
-                  min={0}
-                  max={90}
-                  step={5}
-                  value={segment.tiltDeg}
-                  onChange={(e) => update({ tiltDeg: parseInt(e.target.value) })}
-                  className="w-full accent-primary"
-                />
-              </div>
-
-              <div className="space-y-1">
-                <div className="flex justify-between text-sm">
-                  <label className="font-medium">Retning (azimut)</label>
-                  <span className="text-muted-foreground">{segment.azimuthDeg}°</span>
-                </div>
-                <input
-                  type="range"
-                  min={-180}
-                  max={180}
-                  step={5}
-                  value={segment.azimuthDeg}
-                  onChange={(e) => update({ azimuthDeg: parseInt(e.target.value) })}
-                  className="w-full accent-primary"
-                />
-                <p className="text-xs text-muted-foreground">-90° = øst · 0° = syd · 90° = vest</p>
-              </div>
-            </>
+          {segments.length > 1 && (
+            <p className="text-sm text-amber-700">
+              I alt <span className="font-medium text-amber-900">{totalKw.toFixed(1)} kWp</span> fordelt på {segments.length} tag-flader
+            </p>
           )}
+
+          <div className="space-y-4 divide-y divide-amber-200">
+            {segments.map((segment, i) => (
+              <div key={segment.id} className={i > 0 ? 'pt-4' : undefined}>
+                <RoofSegmentCard
+                  segment={segment}
+                  advanced={advanced}
+                  title={segments.length > 1 ? `Tag-flade ${i + 1}` : undefined}
+                  peakKwMin={0.5}
+                  peakKwMax={30}
+                  peakKwStep={0.5}
+                  onUpdate={(partial) => updateExistingSegment(segment.id, partial)}
+                />
+              </div>
+            ))}
+          </div>
 
           <p className="text-xs text-amber-700 border-t border-amber-200 pt-3">
             Simulationsformen nedenfor repræsenterer den <span className="font-medium">udvidelse</span> du ønsker at beregne oven i dit nuværende anlæg.

--- a/src/components/forms/ExistingSolarForm.tsx
+++ b/src/components/forms/ExistingSolarForm.tsx
@@ -85,7 +85,7 @@ export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) 
               <div key={segment.id} className={i > 0 ? 'pt-4' : undefined}>
                 <RoofSegmentCard
                   segment={segment}
-                  advanced={advanced}
+                  showOrientation={advanced || segments.length > 1}
                   title={segments.length > 1 ? `Tag-flade ${i + 1}` : undefined}
                   peakKwMin={0.5}
                   peakKwMax={30}

--- a/src/components/forms/ExistingSolarForm.tsx
+++ b/src/components/forms/ExistingSolarForm.tsx
@@ -1,23 +1,17 @@
 import { Sun } from 'lucide-react'
-import { useAppStore } from '@/store/appStore'
-
-const DEFAULT_EXISTING: NonNullable<ReturnType<typeof useAppStore.getState>['existingSolarConfig']> = {
-  peakKw: 6,
-  tiltDeg: 35,
-  azimuthDeg: 0,
-  systemLossPct: 5,
-}
+import { useAppStore, defaultExistingSolarConfig } from '@/store/appStore'
 
 export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) {
   const existingSolarConfig    = useAppStore((s) => s.existingSolarConfig)
   const setExistingSolarConfig = useAppStore((s) => s.setExistingSolarConfig)
+  const updateExistingSegment  = useAppStore((s) => s.updateExistingSegment)
 
   const enabled = existingSolarConfig !== null
-  const config  = existingSolarConfig ?? DEFAULT_EXISTING
+  const config  = existingSolarConfig ?? defaultExistingSolarConfig()
+  const segment = config.segments[0]
 
-  const toggle = () => setExistingSolarConfig(enabled ? null : DEFAULT_EXISTING)
-  const update = (partial: Partial<typeof DEFAULT_EXISTING>) =>
-    setExistingSolarConfig({ ...config, ...partial })
+  const toggle = () => setExistingSolarConfig(enabled ? null : defaultExistingSolarConfig())
+  const update = (partial: Partial<typeof segment>) => updateExistingSegment(segment.id, partial)
 
   return (
     <div className="rounded-xl border border-amber-200 bg-amber-50/50 card-shadow p-5 space-y-4">
@@ -53,14 +47,14 @@ export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) 
           <div className="space-y-1">
             <div className="flex justify-between text-sm">
               <label className="font-medium">Installeret effekt</label>
-              <span className="text-muted-foreground">{config.peakKw} kWp</span>
+              <span className="text-muted-foreground">{segment.peakKw} kWp</span>
             </div>
             <input
               type="range"
               min={0.5}
               max={30}
               step={0.5}
-              value={config.peakKw}
+              value={segment.peakKw}
               onChange={(e) => update({ peakKw: parseFloat(e.target.value) })}
               className="w-full accent-primary"
             />
@@ -72,14 +66,14 @@ export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) 
               <div className="space-y-1">
                 <div className="flex justify-between text-sm">
                   <label className="font-medium">Hældning</label>
-                  <span className="text-muted-foreground">{config.tiltDeg}°</span>
+                  <span className="text-muted-foreground">{segment.tiltDeg}°</span>
                 </div>
                 <input
                   type="range"
                   min={0}
                   max={90}
                   step={5}
-                  value={config.tiltDeg}
+                  value={segment.tiltDeg}
                   onChange={(e) => update({ tiltDeg: parseInt(e.target.value) })}
                   className="w-full accent-primary"
                 />
@@ -88,14 +82,14 @@ export function ExistingSolarForm({ advanced = false }: { advanced?: boolean }) 
               <div className="space-y-1">
                 <div className="flex justify-between text-sm">
                   <label className="font-medium">Retning (azimut)</label>
-                  <span className="text-muted-foreground">{config.azimuthDeg}°</span>
+                  <span className="text-muted-foreground">{segment.azimuthDeg}°</span>
                 </div>
                 <input
                   type="range"
                   min={-180}
                   max={180}
                   step={5}
-                  value={config.azimuthDeg}
+                  value={segment.azimuthDeg}
                   onChange={(e) => update({ azimuthDeg: parseInt(e.target.value) })}
                   className="w-full accent-primary"
                 />

--- a/src/components/forms/RoofSegmentCard.tsx
+++ b/src/components/forms/RoofSegmentCard.tsx
@@ -6,7 +6,9 @@ import { SliderField, TiltIllustration, azimuthLabel } from './SliderField'
 
 interface RoofSegmentCardProps {
   segment: RoofSegment
-  advanced: boolean
+  /** Show tilt/azimuth sliders — always true for multi-segment systems, since
+   *  differing orientation is the reason to have more than one segment. */
+  showOrientation: boolean
   title?: string
   peakKwMin?: number
   peakKwMax?: number
@@ -16,7 +18,7 @@ interface RoofSegmentCardProps {
 
 export function RoofSegmentCard({
   segment,
-  advanced,
+  showOrientation,
   title,
   peakKwMin = 1,
   peakKwMax = 50,
@@ -116,7 +118,7 @@ export function RoofSegmentCard({
                 onChange={(v) => onUpdate({ panelWidthM: v })}
               />
               <SliderField
-                label="Panelhøjde"
+                label="Panellængde"
                 value={panel.heightM}
                 min={0.5}
                 max={3}
@@ -140,7 +142,7 @@ export function RoofSegmentCard({
         />
       )}
 
-      {advanced && (
+      {showOrientation && (
         <>
           <SliderField
             label="Hældning"

--- a/src/components/forms/RoofSegmentCard.tsx
+++ b/src/components/forms/RoofSegmentCard.tsx
@@ -1,4 +1,7 @@
+import { useState } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 import type { RoofSegment } from '@/types'
+import { DEFAULT_PANEL, estimateCapacityKw, estimatePanelCount, type PanelSpec } from '@/lib/roofCapacity'
 import { SliderField, TiltIllustration, azimuthLabel } from './SliderField'
 
 interface RoofSegmentCardProps {
@@ -20,20 +23,122 @@ export function RoofSegmentCard({
   peakKwStep = 0.5,
   onUpdate,
 }: RoofSegmentCardProps) {
+  const [panelSpecOpen, setPanelSpecOpen] = useState(false)
+
+  const roofWidthM = segment.roofWidthM ?? 6
+  const roofHeightM = segment.roofHeightM ?? 4
+  const panel: PanelSpec = {
+    wattage: segment.panelWattage ?? DEFAULT_PANEL.wattage,
+    widthM: segment.panelWidthM ?? DEFAULT_PANEL.widthM,
+    heightM: segment.panelHeightM ?? DEFAULT_PANEL.heightM,
+  }
+  const estimatedKw = estimateCapacityKw(roofWidthM, roofHeightM, panel)
+  const panelCount = estimatePanelCount(roofWidthM, roofHeightM, panel)
+
   return (
     <div className="space-y-4">
-      {title && <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>}
+      <div className="flex items-center justify-between">
+        {title && <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>}
+        <div className="flex rounded-lg border border-border bg-muted p-0.5 text-xs ml-auto">
+          <button
+            onClick={() => onUpdate({ inputMode: 'capacity' })}
+            className={`rounded-md px-2 py-1 font-medium transition-colors ${
+              segment.inputMode === 'capacity' ? 'bg-card shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Effekt (kWp)
+          </button>
+          <button
+            onClick={() => onUpdate({
+              inputMode: 'dimensions',
+              roofWidthM: segment.roofWidthM ?? 6,
+              roofHeightM: segment.roofHeightM ?? 4,
+            })}
+            className={`rounded-md px-2 py-1 font-medium transition-colors ${
+              segment.inputMode === 'dimensions' ? 'bg-card shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Tagmål
+          </button>
+        </div>
+      </div>
 
-      <SliderField
-        label="Installeret effekt"
-        value={segment.peakKw}
-        min={peakKwMin}
-        max={peakKwMax}
-        step={peakKwStep}
-        unit="kWp"
-        description="Samlet toppeffekt for denne tag-flade"
-        onChange={(v) => onUpdate({ peakKw: v })}
-      />
+      {segment.inputMode === 'dimensions' ? (
+        <>
+          <SliderField
+            label="Tagbredde"
+            value={roofWidthM}
+            min={1}
+            max={20}
+            step={0.5}
+            unit="m"
+            onChange={(v) => onUpdate({ roofWidthM: v })}
+          />
+          <SliderField
+            label="Taglængde"
+            value={roofHeightM}
+            min={1}
+            max={20}
+            step={0.5}
+            unit="m"
+            onChange={(v) => onUpdate({ roofHeightM: v })}
+          />
+          <p className="text-sm text-muted-foreground">
+            ≈ <span className="font-medium text-foreground">{estimatedKw.toFixed(1)} kWp</span> — {panelCount} paneler (groft estimat)
+          </p>
+
+          <button
+            onClick={() => setPanelSpecOpen((o) => !o)}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {panelSpecOpen ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            Panelspecifikationer
+          </button>
+
+          {panelSpecOpen && (
+            <div className="space-y-3 pl-3 border-l-2 border-border">
+              <SliderField
+                label="Paneleffekt"
+                value={panel.wattage}
+                min={300}
+                max={600}
+                step={10}
+                unit="Wp"
+                onChange={(v) => onUpdate({ panelWattage: v })}
+              />
+              <SliderField
+                label="Panelbredde"
+                value={panel.widthM}
+                min={0.5}
+                max={2.5}
+                step={0.01}
+                unit="m"
+                onChange={(v) => onUpdate({ panelWidthM: v })}
+              />
+              <SliderField
+                label="Panelhøjde"
+                value={panel.heightM}
+                min={0.5}
+                max={3}
+                step={0.01}
+                unit="m"
+                onChange={(v) => onUpdate({ panelHeightM: v })}
+              />
+            </div>
+          )}
+        </>
+      ) : (
+        <SliderField
+          label="Installeret effekt"
+          value={segment.peakKw}
+          min={peakKwMin}
+          max={peakKwMax}
+          step={peakKwStep}
+          unit="kWp"
+          description="Samlet toppeffekt for denne tag-flade"
+          onChange={(v) => onUpdate({ peakKw: v })}
+        />
+      )}
 
       {advanced && (
         <>

--- a/src/components/forms/RoofSegmentCard.tsx
+++ b/src/components/forms/RoofSegmentCard.tsx
@@ -1,0 +1,77 @@
+import type { RoofSegment } from '@/types'
+import { SliderField, TiltIllustration, azimuthLabel } from './SliderField'
+
+interface RoofSegmentCardProps {
+  segment: RoofSegment
+  advanced: boolean
+  title?: string
+  peakKwMin?: number
+  peakKwMax?: number
+  peakKwStep?: number
+  onUpdate: (partial: Partial<RoofSegment>) => void
+}
+
+export function RoofSegmentCard({
+  segment,
+  advanced,
+  title,
+  peakKwMin = 1,
+  peakKwMax = 50,
+  peakKwStep = 0.5,
+  onUpdate,
+}: RoofSegmentCardProps) {
+  return (
+    <div className="space-y-4">
+      {title && <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>}
+
+      <SliderField
+        label="Installeret effekt"
+        value={segment.peakKw}
+        min={peakKwMin}
+        max={peakKwMax}
+        step={peakKwStep}
+        unit="kWp"
+        description="Samlet toppeffekt for denne tag-flade"
+        onChange={(v) => onUpdate({ peakKw: v })}
+      />
+
+      {advanced && (
+        <>
+          <SliderField
+            label="Hældning"
+            value={segment.tiltDeg}
+            min={0}
+            max={90}
+            step={5}
+            unit="°"
+            description="0° = vandret, 35° er typisk for dansk tag"
+            onChange={(v) => onUpdate({ tiltDeg: v })}
+          >
+            <TiltIllustration tiltDeg={segment.tiltDeg} />
+          </SliderField>
+
+          <div className="space-y-1">
+            <div className="flex justify-between text-sm">
+              <label className="font-medium">Retning (azimut)</label>
+              <span className="text-muted-foreground">
+                {azimuthLabel(segment.azimuthDeg)} ({segment.azimuthDeg}°)
+              </span>
+            </div>
+            <input
+              type="range"
+              min={-180}
+              max={180}
+              step={5}
+              value={segment.azimuthDeg}
+              onChange={(e) => onUpdate({ azimuthDeg: parseInt(e.target.value) })}
+              className="w-full accent-primary"
+            />
+            <p className="text-xs text-muted-foreground">
+              -180°/180° = nord, -90° = øst, 0° = syd (optimalt), 90° = vest · Retning vises på kortet
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/forms/RoofSegmentCard.tsx
+++ b/src/components/forms/RoofSegmentCard.tsx
@@ -6,9 +6,6 @@ import { SliderField, TiltIllustration, azimuthLabel } from './SliderField'
 
 interface RoofSegmentCardProps {
   segment: RoofSegment
-  /** Show tilt/azimuth sliders — always true for multi-segment systems, since
-   *  differing orientation is the reason to have more than one segment. */
-  showOrientation: boolean
   title?: string
   peakKwMin?: number
   peakKwMax?: number
@@ -18,7 +15,6 @@ interface RoofSegmentCardProps {
 
 export function RoofSegmentCard({
   segment,
-  showOrientation,
   title,
   peakKwMin = 1,
   peakKwMax = 50,
@@ -26,6 +22,7 @@ export function RoofSegmentCard({
   onUpdate,
 }: RoofSegmentCardProps) {
   const [panelSpecOpen, setPanelSpecOpen] = useState(false)
+  const [orientationOpen, setOrientationOpen] = useState(false)
 
   const roofWidthM = segment.roofWidthM ?? 6
   const roofHeightM = segment.roofHeightM ?? 4
@@ -142,8 +139,16 @@ export function RoofSegmentCard({
         />
       )}
 
-      {showOrientation && (
-        <>
+      <button
+        onClick={() => setOrientationOpen((o) => !o)}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        {orientationOpen ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+        Hældning &amp; retning
+      </button>
+
+      {orientationOpen && (
+        <div className="space-y-4 pl-3 border-l-2 border-border">
           <SliderField
             label="Hældning"
             value={segment.tiltDeg}
@@ -177,7 +182,7 @@ export function RoofSegmentCard({
               -180°/180° = nord, -90° = øst, 0° = syd (optimalt), 90° = vest · Retning vises på kortet
             </p>
           </div>
-        </>
+        </div>
       )}
     </div>
   )

--- a/src/components/forms/RoofSegmentCard.tsx
+++ b/src/components/forms/RoofSegmentCard.tsx
@@ -134,7 +134,7 @@ export function RoofSegmentCard({
           max={peakKwMax}
           step={peakKwStep}
           unit="kWp"
-          description="Samlet toppeffekt for denne tag-flade"
+          description="Samlet installeret effekt for denne tag-flade"
           onChange={(v) => onUpdate({ peakKw: v })}
         />
       )}

--- a/src/components/forms/SliderField.tsx
+++ b/src/components/forms/SliderField.tsx
@@ -1,0 +1,136 @@
+interface SliderFieldProps {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  unit: string
+  description?: string
+  onChange: (v: number) => void
+  children?: React.ReactNode
+}
+
+export function SliderField({ label, value, min, max, step, unit, description, onChange, children }: SliderFieldProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-sm">
+        <label className="font-medium">{label}</label>
+        <span className="text-muted-foreground">{value} {unit}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-primary"
+      />
+      {children}
+      {description && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
+    </div>
+  )
+}
+
+export function TiltIllustration({ tiltDeg }: { tiltDeg: number }) {
+  const rad = (tiltDeg * Math.PI) / 180
+  // Panel: pivot at bottom-left corner, rotates upward to the right
+  const px = 90, py = 130  // pivot point (bottom-left of panel)
+  const panelW = 150, panelH = 10
+
+  // Angle arc
+  const arcR = 38
+  const arcEndX = px + arcR * Math.cos(rad)
+  const arcEndY = py - arcR * Math.sin(rad)
+
+  // Label at midpoint of arc
+  const labelR = arcR + 18
+  const labelX = px + labelR * Math.cos(rad / 2)
+  const labelY = py - labelR * Math.sin(rad / 2)
+
+  // Cell divider positions (5 dividers = 6 cells)
+  const cellDividers = [1, 2, 3, 4, 5]
+
+  return (
+    <svg viewBox="0 0 320 145" className="w-full h-28 mt-1">
+      {/* Ground line */}
+      <line
+        x1="0" y1={py + 3} x2="320" y2={py + 3}
+        style={{ stroke: 'hsl(var(--border))' }} strokeWidth="1.5"
+      />
+
+      {/* Sun — fixed upper-left */}
+      <circle cx="38" cy="22" r="18"
+        style={{ fill: 'hsl(var(--primary))' }} opacity="0.12" />
+      <circle cx="38" cy="22" r="10"
+        style={{ fill: 'hsl(var(--primary))' }} opacity="0.9" />
+
+      {/* Angle arc */}
+      {tiltDeg > 2 && (
+        <path
+          d={`M ${px + arcR} ${py} A ${arcR} ${arcR} 0 0 0 ${arcEndX} ${arcEndY}`}
+          fill="none"
+          style={{ stroke: 'hsl(var(--primary))' }}
+          strokeWidth="1.5"
+          opacity="0.45"
+        />
+      )}
+
+      {/* Angle label */}
+      {tiltDeg > 6 && (
+        <text
+          x={labelX} y={labelY}
+          fontSize="13"
+          style={{ fill: 'hsl(var(--muted-foreground))', fontFamily: 'Inter, system-ui, sans-serif' }}
+          textAnchor="middle" dominantBaseline="middle"
+        >
+          {tiltDeg}°
+        </text>
+      )}
+
+      {/* Solar panel — rotated rectangle around pivot */}
+      <g transform={`rotate(${-tiltDeg} ${px} ${py})`}>
+        {/* Panel body */}
+        <rect
+          x={px} y={py - panelH} width={panelW} height={panelH} rx="2.5"
+          fill="#1e3a5f"
+        />
+        {/* Subtle cell grid */}
+        {cellDividers.map(i => (
+          <line
+            key={i}
+            x1={px + (panelW / 6) * i} y1={py - panelH}
+            x2={px + (panelW / 6) * i} y2={py}
+            stroke="#60a5fa" strokeWidth="0.7" opacity="0.3"
+          />
+        ))}
+        {/* Top-edge highlight */}
+        <line
+          x1={px + 3} y1={py - panelH + 1.5} x2={px + panelW - 3} y2={py - panelH + 1.5}
+          stroke="#93c5fd" strokeWidth="1" opacity="0.25" strokeLinecap="round"
+        />
+      </g>
+
+      {/* Pivot dot */}
+      <circle cx={px} cy={py} r="3"
+        style={{ fill: 'hsl(var(--muted-foreground))' }} opacity="0.4"
+      />
+    </svg>
+  )
+}
+
+export function azimuthLabel(deg: number): string {
+  const d = ((deg % 360) + 360) % 360  // normalise to 0–360 for lookup
+  const normalised = d > 180 ? d - 360 : d  // back to -180..180
+  if (normalised <= -157) return 'Nord'
+  if (normalised <= -112) return 'Nord-øst'
+  if (normalised <= -67)  return 'Øst'
+  if (normalised <= -22)  return 'Øst-syd'
+  if (normalised <= 22)   return 'Syd'
+  if (normalised <= 67)   return 'Syd-vest'
+  if (normalised <= 112)  return 'Vest'
+  if (normalised <= 157)  return 'Nord-vest'
+  return 'Nord'
+}

--- a/src/components/forms/SolarConfigForm.tsx
+++ b/src/components/forms/SolarConfigForm.tsx
@@ -59,7 +59,6 @@ export function SolarConfigForm({ label, advanced = false }: { label?: string; a
           <div key={segment.id} className={i > 0 ? 'pt-5' : undefined}>
             <RoofSegmentCard
               segment={segment}
-              showOrientation={advanced || segments.length > 1}
               title={segments.length > 1 ? `Tag-flade ${i + 1}` : undefined}
               peakKwMin={1}
               peakKwMax={50}

--- a/src/components/forms/SolarConfigForm.tsx
+++ b/src/components/forms/SolarConfigForm.tsx
@@ -1,215 +1,87 @@
 import { Sun } from 'lucide-react'
-import { useAppStore } from '@/store/appStore'
-
-interface SliderFieldProps {
-  label: string
-  value: number
-  min: number
-  max: number
-  step: number
-  unit: string
-  description?: string
-  onChange: (v: number) => void
-  children?: React.ReactNode
-}
-
-function SliderField({ label, value, min, max, step, unit, description, onChange, children }: SliderFieldProps) {
-  return (
-    <div className="space-y-1">
-      <div className="flex justify-between text-sm">
-        <label className="font-medium">{label}</label>
-        <span className="text-muted-foreground">{value} {unit}</span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full accent-primary"
-      />
-      {children}
-      {description && (
-        <p className="text-xs text-muted-foreground">{description}</p>
-      )}
-    </div>
-  )
-}
-
-function TiltIllustration({ tiltDeg }: { tiltDeg: number }) {
-  const rad = (tiltDeg * Math.PI) / 180
-  // Panel: pivot at bottom-left corner, rotates upward to the right
-  const px = 90, py = 130  // pivot point (bottom-left of panel)
-  const panelW = 150, panelH = 10
-
-  // Angle arc
-  const arcR = 38
-  const arcEndX = px + arcR * Math.cos(rad)
-  const arcEndY = py - arcR * Math.sin(rad)
-
-  // Label at midpoint of arc
-  const labelR = arcR + 18
-  const labelX = px + labelR * Math.cos(rad / 2)
-  const labelY = py - labelR * Math.sin(rad / 2)
-
-  // Cell divider positions (5 dividers = 6 cells)
-  const cellDividers = [1, 2, 3, 4, 5]
-
-  return (
-    <svg viewBox="0 0 320 145" className="w-full h-28 mt-1">
-      {/* Ground line */}
-      <line
-        x1="0" y1={py + 3} x2="320" y2={py + 3}
-        style={{ stroke: 'hsl(var(--border))' }} strokeWidth="1.5"
-      />
-
-      {/* Sun — fixed upper-left */}
-      <circle cx="38" cy="22" r="18"
-        style={{ fill: 'hsl(var(--primary))' }} opacity="0.12" />
-      <circle cx="38" cy="22" r="10"
-        style={{ fill: 'hsl(var(--primary))' }} opacity="0.9" />
-
-      {/* Angle arc */}
-      {tiltDeg > 2 && (
-        <path
-          d={`M ${px + arcR} ${py} A ${arcR} ${arcR} 0 0 0 ${arcEndX} ${arcEndY}`}
-          fill="none"
-          style={{ stroke: 'hsl(var(--primary))' }}
-          strokeWidth="1.5"
-          opacity="0.45"
-        />
-      )}
-
-      {/* Angle label */}
-      {tiltDeg > 6 && (
-        <text
-          x={labelX} y={labelY}
-          fontSize="13"
-          style={{ fill: 'hsl(var(--muted-foreground))', fontFamily: 'Inter, system-ui, sans-serif' }}
-          textAnchor="middle" dominantBaseline="middle"
-        >
-          {tiltDeg}°
-        </text>
-      )}
-
-      {/* Solar panel — rotated rectangle around pivot */}
-      <g transform={`rotate(${-tiltDeg} ${px} ${py})`}>
-        {/* Panel body */}
-        <rect
-          x={px} y={py - panelH} width={panelW} height={panelH} rx="2.5"
-          fill="#1e3a5f"
-        />
-        {/* Subtle cell grid */}
-        {cellDividers.map(i => (
-          <line
-            key={i}
-            x1={px + (panelW / 6) * i} y1={py - panelH}
-            x2={px + (panelW / 6) * i} y2={py}
-            stroke="#60a5fa" strokeWidth="0.7" opacity="0.3"
-          />
-        ))}
-        {/* Top-edge highlight */}
-        <line
-          x1={px + 3} y1={py - panelH + 1.5} x2={px + panelW - 3} y2={py - panelH + 1.5}
-          stroke="#93c5fd" strokeWidth="1" opacity="0.25" strokeLinecap="round"
-        />
-      </g>
-
-      {/* Pivot dot */}
-      <circle cx={px} cy={py} r="3"
-        style={{ fill: 'hsl(var(--muted-foreground))' }} opacity="0.4"
-      />
-    </svg>
-  )
-}
+import { useAppStore, MAX_SEGMENTS } from '@/store/appStore'
+import { getSegmentPeakKw } from '@/lib/roofCapacity'
+import { SliderField } from './SliderField'
+import { RoofSegmentCard } from './RoofSegmentCard'
 
 export function SolarConfigForm({ label, advanced = false }: { label?: string; advanced?: boolean }) {
   const solarConfig = useAppStore((s) => s.solarConfig)
+  const addSolarSegment = useAppStore((s) => s.addSolarSegment)
+  const removeSolarSegment = useAppStore((s) => s.removeSolarSegment)
   const updateSolarSegment = useAppStore((s) => s.updateSolarSegment)
   const setSystemLossPct = useAppStore((s) => s.setSystemLossPct)
-  const segment = solarConfig.segments[0]
+
+  const segments = solarConfig.segments
+  const totalKw = segments.reduce((sum, seg) => sum + getSegmentPeakKw(seg), 0)
+
+  const setSegmentCount = (target: number) => {
+    const current = segments.length
+    if (target > current) {
+      for (let i = current; i < target; i++) addSolarSegment()
+    } else if (target < current) {
+      segments.slice(target).forEach((seg) => removeSolarSegment(seg.id))
+    }
+  }
 
   return (
     <div className="rounded-xl border border-border bg-card card-shadow p-5 space-y-5">
-      <h2 className="font-semibold flex items-center gap-2">
-        <Sun className="h-4 w-4 text-primary" />
-        {label ?? 'Solcelleanlæg'}
-      </h2>
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold flex items-center gap-2">
+          <Sun className="h-4 w-4 text-primary" />
+          {label ?? 'Solcelleanlæg'}
+        </h2>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Antal tag-flader</span>
+          <div className="flex rounded-lg border border-border bg-muted p-0.5 text-sm">
+            {Array.from({ length: MAX_SEGMENTS }, (_, i) => i + 1).map((n) => (
+              <button
+                key={n}
+                onClick={() => setSegmentCount(n)}
+                className={`rounded-md px-2.5 py-1 font-medium transition-colors ${
+                  segments.length === n ? 'bg-card shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
 
-      <SliderField
-        label="Installeret effekt"
-        value={segment.peakKw}
-        min={1}
-        max={50}
-        step={0.5}
-        unit="kWp"
-        description="Samlet toppeffekt for dit anlæg"
-        onChange={(v) => updateSolarSegment(segment.id, { peakKw: v })}
-      />
+      {segments.length > 1 && (
+        <p className="text-sm text-muted-foreground -mt-2">
+          I alt <span className="font-medium text-foreground">{totalKw.toFixed(1)} kWp</span> fordelt på {segments.length} tag-flader
+        </p>
+      )}
+
+      <div className="space-y-5 divide-y divide-border">
+        {segments.map((segment, i) => (
+          <div key={segment.id} className={i > 0 ? 'pt-5' : undefined}>
+            <RoofSegmentCard
+              segment={segment}
+              advanced={advanced}
+              title={segments.length > 1 ? `Tag-flade ${i + 1}` : undefined}
+              peakKwMin={1}
+              peakKwMax={50}
+              peakKwStep={0.5}
+              onUpdate={(partial) => updateSolarSegment(segment.id, partial)}
+            />
+          </div>
+        ))}
+      </div>
 
       {advanced && (
-        <>
-          <SliderField
-            label="Hældning"
-            value={segment.tiltDeg}
-            min={0}
-            max={90}
-            step={5}
-            unit="°"
-            description="0° = vandret, 35° er typisk for dansk tag"
-            onChange={(v) => updateSolarSegment(segment.id, { tiltDeg: v })}
-          >
-            <TiltIllustration tiltDeg={segment.tiltDeg} />
-          </SliderField>
-
-          <div className="space-y-1">
-            <div className="flex justify-between text-sm">
-              <label className="font-medium">Retning (azimut)</label>
-              <span className="text-muted-foreground">
-                {azimuthLabel(segment.azimuthDeg)} ({segment.azimuthDeg}°)
-              </span>
-            </div>
-            <input
-              type="range"
-              min={-180}
-              max={180}
-              step={5}
-              value={segment.azimuthDeg}
-              onChange={(e) => updateSolarSegment(segment.id, { azimuthDeg: parseInt(e.target.value) })}
-              className="w-full accent-primary"
-            />
-            <p className="text-xs text-muted-foreground">
-              -180°/180° = nord, -90° = øst, 0° = syd (optimalt), 90° = vest · Retning vises på kortet
-            </p>
-          </div>
-
-          <SliderField
-            label="Systemtab"
-            value={solarConfig.systemLossPct}
-            min={0}
-            max={30}
-            step={1}
-            unit="%"
-            description="Inkl. temperatur, kabelstab, vekselretter, snavs og degradering. 14% er PVGIS' realistiske standard."
-            onChange={(v) => setSystemLossPct(v)}
-          />
-        </>
+        <SliderField
+          label="Systemtab"
+          value={solarConfig.systemLossPct}
+          min={0}
+          max={30}
+          step={1}
+          unit="%"
+          description="Inkl. temperatur, kabelstab, vekselretter, snavs og degradering. 14% er PVGIS' realistiske standard."
+          onChange={(v) => setSystemLossPct(v)}
+        />
       )}
     </div>
   )
-}
-
-function azimuthLabel(deg: number): string {
-  const d = ((deg % 360) + 360) % 360  // normalise to 0–360 for lookup
-  const normalised = d > 180 ? d - 360 : d  // back to -180..180
-  if (normalised <= -157) return 'Nord'
-  if (normalised <= -112) return 'Nord-øst'
-  if (normalised <= -67)  return 'Øst'
-  if (normalised <= -22)  return 'Øst-syd'
-  if (normalised <= 22)   return 'Syd'
-  if (normalised <= 67)   return 'Syd-vest'
-  if (normalised <= 112)  return 'Vest'
-  if (normalised <= 157)  return 'Nord-vest'
-  return 'Nord'
 }

--- a/src/components/forms/SolarConfigForm.tsx
+++ b/src/components/forms/SolarConfigForm.tsx
@@ -125,7 +125,10 @@ function TiltIllustration({ tiltDeg }: { tiltDeg: number }) {
 }
 
 export function SolarConfigForm({ label, advanced = false }: { label?: string; advanced?: boolean }) {
-  const { solarConfig, setSolarConfig } = useAppStore()
+  const solarConfig = useAppStore((s) => s.solarConfig)
+  const updateSolarSegment = useAppStore((s) => s.updateSolarSegment)
+  const setSystemLossPct = useAppStore((s) => s.setSystemLossPct)
+  const segment = solarConfig.segments[0]
 
   return (
     <div className="rounded-xl border border-border bg-card card-shadow p-5 space-y-5">
@@ -136,35 +139,35 @@ export function SolarConfigForm({ label, advanced = false }: { label?: string; a
 
       <SliderField
         label="Installeret effekt"
-        value={solarConfig.peakKw}
+        value={segment.peakKw}
         min={1}
         max={50}
         step={0.5}
         unit="kWp"
         description="Samlet toppeffekt for dit anlæg"
-        onChange={(v) => setSolarConfig({ peakKw: v })}
+        onChange={(v) => updateSolarSegment(segment.id, { peakKw: v })}
       />
 
       {advanced && (
         <>
           <SliderField
             label="Hældning"
-            value={solarConfig.tiltDeg}
+            value={segment.tiltDeg}
             min={0}
             max={90}
             step={5}
             unit="°"
             description="0° = vandret, 35° er typisk for dansk tag"
-            onChange={(v) => setSolarConfig({ tiltDeg: v })}
+            onChange={(v) => updateSolarSegment(segment.id, { tiltDeg: v })}
           >
-            <TiltIllustration tiltDeg={solarConfig.tiltDeg} />
+            <TiltIllustration tiltDeg={segment.tiltDeg} />
           </SliderField>
 
           <div className="space-y-1">
             <div className="flex justify-between text-sm">
               <label className="font-medium">Retning (azimut)</label>
               <span className="text-muted-foreground">
-                {azimuthLabel(solarConfig.azimuthDeg)} ({solarConfig.azimuthDeg}°)
+                {azimuthLabel(segment.azimuthDeg)} ({segment.azimuthDeg}°)
               </span>
             </div>
             <input
@@ -172,8 +175,8 @@ export function SolarConfigForm({ label, advanced = false }: { label?: string; a
               min={-180}
               max={180}
               step={5}
-              value={solarConfig.azimuthDeg}
-              onChange={(e) => setSolarConfig({ azimuthDeg: parseInt(e.target.value) })}
+              value={segment.azimuthDeg}
+              onChange={(e) => updateSolarSegment(segment.id, { azimuthDeg: parseInt(e.target.value) })}
               className="w-full accent-primary"
             />
             <p className="text-xs text-muted-foreground">
@@ -189,7 +192,7 @@ export function SolarConfigForm({ label, advanced = false }: { label?: string; a
             step={1}
             unit="%"
             description="Inkl. temperatur, kabelstab, vekselretter, snavs og degradering. 14% er PVGIS' realistiske standard."
-            onChange={(v) => setSolarConfig({ systemLossPct: v })}
+            onChange={(v) => setSystemLossPct(v)}
           />
         </>
       )}

--- a/src/components/forms/SolarConfigForm.tsx
+++ b/src/components/forms/SolarConfigForm.tsx
@@ -59,7 +59,7 @@ export function SolarConfigForm({ label, advanced = false }: { label?: string; a
           <div key={segment.id} className={i > 0 ? 'pt-5' : undefined}>
             <RoofSegmentCard
               segment={segment}
-              advanced={advanced}
+              showOrientation={advanced || segments.length > 1}
               title={segments.length > 1 ? `Tag-flade ${i + 1}` : undefined}
               peakKwMin={1}
               peakKwMax={50}

--- a/src/components/map/AddressMap.tsx
+++ b/src/components/map/AddressMap.tsx
@@ -52,10 +52,10 @@ function FlyTo({ coords }: { coords: Coordinates }) {
 interface Props {
   coordinates: Coordinates
   displayName: string
-  azimuthDeg?: number
+  azimuthDegs?: number[]
 }
 
-export function AddressMap({ coordinates, displayName, azimuthDeg }: Props) {
+export function AddressMap({ coordinates, displayName, azimuthDegs }: Props) {
   return (
     <div className="rounded-md overflow-hidden border border-border h-48">
       <MapContainer
@@ -70,14 +70,15 @@ export function AddressMap({ coordinates, displayName, azimuthDeg }: Props) {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <FlyTo coords={coordinates} />
-        {/* Direction arrow behind the pin */}
-        {azimuthDeg !== undefined && (
+        {/* Direction arrows behind the pin — one per roof segment */}
+        {azimuthDegs?.map((deg, i) => (
           <Marker
+            key={i}
             position={[coordinates.lat, coordinates.lon]}
-            icon={makeArrowIcon(azimuthDeg)}
+            icon={makeArrowIcon(deg)}
             zIndexOffset={-100}
           />
-        )}
+        ))}
         {/* Address pin */}
         <Marker position={[coordinates.lat, coordinates.lon]} icon={markerIcon}>
           <Popup maxWidth={240}>

--- a/src/components/results/ResultsPanel.tsx
+++ b/src/components/results/ResultsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ChevronDown, ChevronUp, Zap } from 'lucide-react'
 import { useAppStore } from '@/store/appStore'
+import { getSegmentPeakKw } from '@/lib/roofCapacity'
 import { useSimulation } from '@/hooks/useSimulation'
 import { SummaryCards } from './SummaryCards'
 import { EnergyFlowChart } from './EnergyFlowChart'
@@ -33,8 +34,10 @@ export function ResultsPanel({ advanced = false }: { advanced?: boolean }) {
   // Derive data year from first hourly entry (format: "2023-01-01T…")
   const dataYear = simulationResult.hourly[0]?.hourStart.slice(0, 4) ?? null
 
-  const primarySegment = solarConfig.segments[0]
-  const systemDesc = `${primarySegment.peakKw} kWp · ${azimuthShort(primarySegment.azimuthDeg)} · ${primarySegment.tiltDeg}° hældning`
+  const segments = solarConfig.segments
+  const systemDesc = segments.length > 1
+    ? `${segments.reduce((sum, seg) => sum + getSegmentPeakKw(seg), 0).toFixed(1)} kWp samlet · ${segments.length} tag-flader`
+    : `${getSegmentPeakKw(segments[0])} kWp · ${azimuthShort(segments[0].azimuthDeg)} · ${segments[0].tiltDeg}° hældning`
   const shortAddress = address.split(',')[0]?.trim()
 
   return (

--- a/src/components/results/ResultsPanel.tsx
+++ b/src/components/results/ResultsPanel.tsx
@@ -33,7 +33,8 @@ export function ResultsPanel({ advanced = false }: { advanced?: boolean }) {
   // Derive data year from first hourly entry (format: "2023-01-01T…")
   const dataYear = simulationResult.hourly[0]?.hourStart.slice(0, 4) ?? null
 
-  const systemDesc = `${solarConfig.peakKw} kWp · ${azimuthShort(solarConfig.azimuthDeg)} · ${solarConfig.tiltDeg}° hældning`
+  const primarySegment = solarConfig.segments[0]
+  const systemDesc = `${primarySegment.peakKw} kWp · ${azimuthShort(primarySegment.azimuthDeg)} · ${primarySegment.tiltDeg}° hældning`
   const shortAddress = address.split(',')[0]?.trim()
 
   return (

--- a/src/hooks/useSimulation.test.ts
+++ b/src/hooks/useSimulation.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/simulation')
 // --- Imports after mocks ---
 
 import { useAppStore } from '@/store/appStore'
-import { fetchPVGISData } from '@/lib/pvgis'
+import { fetchPVGISDataForSegments } from '@/lib/pvgis'
 import { fetchSpotPrices, fetchCO2Emissions } from '@/lib/energidataservice'
 import { fetchGridTariff, dsoFromPostcode } from '@/lib/gridtariff'
 import { runSimulation } from '@/lib/simulation'
@@ -53,10 +53,15 @@ const MOCK_RESULT: SimulationResult = {
   },
 }
 
+const DEFAULT_SOLAR_CONFIG = {
+  systemLossPct: 5,
+  segments: [{ id: 's1', inputMode: 'capacity' as const, peakKw: 6, tiltDeg: 35, azimuthDeg: 0 }],
+}
+
 const DEFAULT_STORE = {
   coordinates: { lat: 56.15, lon: 10.20 },
   postcode: '2100',
-  solarConfig: { peakKw: 6, tiltDeg: 35, azimuthDeg: 0, systemLossPct: 5 },
+  solarConfig: DEFAULT_SOLAR_CONFIG,
   consumption: { source: 'manual' as const, annualKwh: 5000 },
   priceArea: 'DK2' as const,
   fixedSpotDkk: null,
@@ -77,7 +82,7 @@ beforeEach(() => {
   vi.mocked(useAppStore).mockReturnValue({ ...DEFAULT_STORE, setPVGISData: vi.fn(), setSimulationResult: vi.fn() })
 
   // API defaults
-  vi.mocked(fetchPVGISData).mockResolvedValue(makePVGIS())
+  vi.mocked(fetchPVGISDataForSegments).mockResolvedValue(makePVGIS())
   vi.mocked(fetchSpotPrices).mockResolvedValue([])
   vi.mocked(fetchCO2Emissions).mockRejectedValue(new Error('mocked'))
   vi.mocked(fetchGridTariff).mockRejectedValue(new Error('mocked'))
@@ -125,7 +130,7 @@ describe('useSimulation — missing coordinates', () => {
     const ok = await run()
 
     expect(ok).toBe(false)
-    expect(fetchPVGISData).not.toHaveBeenCalled()
+    expect(fetchPVGISDataForSegments).not.toHaveBeenCalled()
     expect(runSimulation).not.toHaveBeenCalled()
   })
 })
@@ -146,8 +151,11 @@ describe('useSimulation — basic happy path', () => {
     expect(setSimulationResult).toHaveBeenCalledWith(MOCK_RESULT)
   })
 
-  it('fetches PVGIS with the configured solar system', async () => {
-    const solarConfig = { peakKw: 10, tiltDeg: 30, azimuthDeg: 45, systemLossPct: 8 }
+  it('fetches PVGIS with the configured solar segments', async () => {
+    const solarConfig = {
+      systemLossPct: 8,
+      segments: [{ id: 's1', inputMode: 'capacity' as const, peakKw: 10, tiltDeg: 30, azimuthDeg: 45 }],
+    }
     vi.mocked(useAppStore).mockReturnValue({
       ...DEFAULT_STORE,
       solarConfig,
@@ -158,9 +166,10 @@ describe('useSimulation — basic happy path', () => {
     const { runSimulation: run } = useSimulation()
     await run()
 
-    expect(fetchPVGISData).toHaveBeenCalledWith(
+    expect(fetchPVGISDataForSegments).toHaveBeenCalledWith(
       DEFAULT_STORE.coordinates,
-      solarConfig,
+      solarConfig.segments,
+      solarConfig.systemLossPct,
       DEFAULT_STORE.dataYear,
     )
   })
@@ -245,7 +254,7 @@ describe('useSimulation — fixed spot price', () => {
     const EUR_TO_DKK = 7.46
     const fixedSpotDkk = 0.60  // DKK/kWh
     const pvgis = makePVGIS(1000, 24)
-    vi.mocked(fetchPVGISData).mockResolvedValue(pvgis)
+    vi.mocked(fetchPVGISDataForSegments).mockResolvedValue(pvgis)
     vi.mocked(useAppStore).mockReturnValue({
       ...DEFAULT_STORE,
       fixedSpotDkk,
@@ -297,12 +306,15 @@ describe('useSimulation — gross consumption reconstruction', () => {
     const pvgisNew      = makePVGIS(1000, 3)
     const pvgisExisting = makePVGIS(existingWatts, 3)
 
-    // fetchPVGISData called twice: first for new system, second for existing
-    vi.mocked(fetchPVGISData)
+    // fetchPVGISDataForSegments called twice: first for new system, second for existing
+    vi.mocked(fetchPVGISDataForSegments)
       .mockResolvedValueOnce(pvgisNew)
       .mockResolvedValueOnce(pvgisExisting)
 
-    const existingSolarConfig = { peakKw: 3, tiltDeg: 30, azimuthDeg: 0, systemLossPct: 5 }
+    const existingSolarConfig = {
+      systemLossPct: 5,
+      segments: [{ id: 'e1', inputMode: 'capacity' as const, peakKw: 3, tiltDeg: 30, azimuthDeg: 0 }],
+    }
     vi.mocked(useAppStore).mockReturnValue({
       ...DEFAULT_STORE,
       existingSolarConfig,
@@ -349,8 +361,8 @@ describe('useSimulation — gross consumption reconstruction', () => {
     const { runSimulation: run } = useSimulation()
     await run()
 
-    // Only one fetchPVGISData call (no existing system fetch)
-    expect(fetchPVGISData).toHaveBeenCalledTimes(1)
+    // Only one fetchPVGISDataForSegments call (no existing system fetch)
+    expect(fetchPVGISDataForSegments).toHaveBeenCalledTimes(1)
     const effectiveConsumption = vi.mocked(runSimulation).mock.calls[0]?.[1]
     expect(effectiveConsumption?.hourlyKwh).toEqual([1, 2, 3])
   })

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useAppStore } from '@/store/appStore'
-import { fetchPVGISData, pvgisTimeToCopenhagenHour } from '@/lib/pvgis'
+import { fetchPVGISDataForSegments, pvgisTimeToCopenhagenHour } from '@/lib/pvgis'
 import { fetchSpotPrices, fetchCO2Emissions, VAT_MULTIPLIER, EUR_TO_DKK } from '@/lib/energidataservice'
 import { fetchGridTariff, dsoFromPostcode, ELAFGIFT_DKK, SYSTEM_TARIFF_DKK, FALLBACK_NETTARIF_DKK } from '@/lib/gridtariff'
 import { runSimulation, HEATPUMP_ADDON_KWH } from '@/lib/simulation'
@@ -43,10 +43,10 @@ export function useSimulation() {
         : dsoFromPostcode(postcode)
 
       const [pvgis, pvgisExisting, rawPrices, tariff24, co2Factors] = await Promise.all([
-        fetchPVGISData(coordinates, solarConfig, dataYear),
+        fetchPVGISDataForSegments(coordinates, solarConfig.segments, solarConfig.systemLossPct, dataYear),
         // Fetch existing system PVGIS in parallel when user has solar already installed
         existingSolarConfig && consumption.hasExport
-          ? fetchPVGISData(coordinates, existingSolarConfig, dataYear)
+          ? fetchPVGISDataForSegments(coordinates, existingSolarConfig.segments, existingSolarConfig.systemLossPct, dataYear)
           : Promise.resolve(null),
         // Skip spot price fetch when user has set a fixed spot price
         fixedSpotDkk === null

--- a/src/lib/pvgis.test.ts
+++ b/src/lib/pvgis.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { pvgisTimeToISO, pvgisTimeToCopenhagenHour, fetchPVGISData } from './pvgis'
-import type { SolarConfig } from '@/types'
+import { pvgisTimeToISO, pvgisTimeToCopenhagenHour, fetchPVGISData, fetchPVGISDataForSegments, type PVSystemParams } from './pvgis'
+import type { RoofSegment } from '@/types'
 
 const COORDS = { lat: 56.15, lon: 10.21 }
-const CONFIG: SolarConfig = { peakKw: 6, tiltDeg: 35, azimuthDeg: 0, systemLossPct: 14 }
+const CONFIG: PVSystemParams = { peakKw: 6, tiltDeg: 35, azimuthDeg: 0, systemLossPct: 14 }
 
 // Minimal PVGIS seriescalc response matching the real API shape.
 // The real API returns { outputs: { hourly: [...] } } — NO totals field.
@@ -129,5 +129,71 @@ describe('fetchPVGISData', () => {
   it('throws on non-ok HTTP response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 400 }))
     await expect(fetchPVGISData(COORDS, CONFIG)).rejects.toThrow('400')
+  })
+})
+
+// --- fetchPVGISDataForSegments ---
+
+describe('fetchPVGISDataForSegments', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  const segments: RoofSegment[] = [
+    { id: 'a', inputMode: 'capacity', peakKw: 6, tiltDeg: 35, azimuthDeg: -90 },
+    { id: 'b', inputMode: 'capacity', peakKw: 4, tiltDeg: 35, azimuthDeg: 90 },
+  ]
+
+  it('sums hourly production across segments index-by-index', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeRealPVGISResponse(3),
+    }))
+
+    const data = await fetchPVGISDataForSegments(COORDS, segments, 14)
+
+    // Each segment returns the same fixture (P: 0, 1000, 2000) — summed = 0, 2000, 4000
+    expect(data.hourly.map((h) => h.P)).toEqual([0, 2000, 4000])
+    expect(data.annualKwh).toBeCloseTo(6) // 3 kWh per segment * 2
+  })
+
+  it('fetches one segment per PVGIS request', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeRealPVGISResponse(2),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await fetchPVGISDataForSegments(COORDS, segments, 14)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves dimensions-mode segments via getSegmentPeakKw before requesting', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeRealPVGISResponse(1),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const dimensionSegment: RoofSegment[] = [
+      { id: 'c', inputMode: 'dimensions', tiltDeg: 35, azimuthDeg: 0, peakKw: 0, roofWidthM: 10, roofHeightM: 6 },
+    ]
+    await fetchPVGISDataForSegments(COORDS, dimensionSegment, 14)
+
+    const url: string = mockFetch.mock.calls[0][0]
+    const peakpower = new URLSearchParams(url.split('?')[1]).get('peakpower')
+    expect(Number(peakpower)).toBeCloseTo(8.36, 1)
+  })
+
+  it('single segment matches a plain fetchPVGISData call', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeRealPVGISResponse(2),
+    }))
+
+    const single = await fetchPVGISDataForSegments(COORDS, [segments[0]], 14)
+    const direct = await fetchPVGISData(COORDS, { ...CONFIG, peakKw: 6, azimuthDeg: -90 })
+
+    expect(single.hourly).toEqual(direct.hourly)
+    expect(single.annualKwh).toBeCloseTo(direct.annualKwh)
   })
 })

--- a/src/lib/pvgis.ts
+++ b/src/lib/pvgis.ts
@@ -1,4 +1,5 @@
-import type { Coordinates, PVGISData, SolarConfig } from '@/types'
+import type { Coordinates, PVGISData, RoofSegment } from '@/types'
+import { getSegmentPeakKw } from './roofCapacity'
 
 // Requests go through /api/pvgis which is proxied to re.jrc.ec.europa.eu
 // in both dev (Vite proxy) and production (nginx proxy_pass).
@@ -12,6 +13,13 @@ export const PVGIS_MAX_YEAR = 2023
 /** @deprecated Use PVGIS_MAX_YEAR for the default year */
 export const DATA_YEAR = PVGIS_MAX_YEAR
 
+export interface PVSystemParams {
+  peakKw: number
+  tiltDeg: number
+  azimuthDeg: number
+  systemLossPct: number
+}
+
 /**
  * Fetches hourly PV production data for a single year from PVGIS (EU Commission).
  * Free, no API key required.
@@ -21,16 +29,16 @@ export const DATA_YEAR = PVGIS_MAX_YEAR
  */
 export async function fetchPVGISData(
   coords: Coordinates,
-  config: SolarConfig,
+  system: PVSystemParams,
   year: number = DATA_YEAR,
 ): Promise<PVGISData> {
   const params = new URLSearchParams({
     lat: coords.lat.toString(),
     lon: coords.lon.toString(),
-    peakpower: config.peakKw.toString(),
-    loss: config.systemLossPct.toString(),
-    angle: config.tiltDeg.toString(),
-    aspect: config.azimuthDeg.toString(),
+    peakpower: system.peakKw.toString(),
+    loss: system.systemLossPct.toString(),
+    angle: system.tiltDeg.toString(),
+    aspect: system.azimuthDeg.toString(),
     startyear: year.toString(),
     endyear: year.toString(),
     outputformat: 'json',
@@ -56,6 +64,44 @@ export async function fetchPVGISData(
 
   // seriescalc has no totals field — derive annual kWh from hourly P (W → kWh)
   const annualKwh = hourly.reduce((sum: number, h: { P: number }) => sum + h.P / 1000, 0)
+
+  return { hourly, annualKwh, location: coords }
+}
+
+/**
+ * Fetches PV production for each roof segment in parallel and sums the
+ * hourly production arrays into one combined result. Segments share the
+ * same year, so their hourly arrays line up index-for-index.
+ */
+export async function fetchPVGISDataForSegments(
+  coords: Coordinates,
+  segments: RoofSegment[],
+  systemLossPct: number,
+  year: number = DATA_YEAR,
+): Promise<PVGISData> {
+  const results = await Promise.all(
+    segments.map((segment) =>
+      fetchPVGISData(
+        coords,
+        {
+          peakKw: getSegmentPeakKw(segment),
+          tiltDeg: segment.tiltDeg,
+          azimuthDeg: segment.azimuthDeg,
+          systemLossPct,
+        },
+        year,
+      ),
+    ),
+  )
+
+  const [first, ...rest] = results
+  const hourly = first.hourly.map((row, i) => ({
+    time: row.time,
+    P: rest.reduce((sum, r) => sum + r.hourly[i].P, row.P),
+    G_i: row.G_i,
+    T2m: row.T2m,
+  }))
+  const annualKwh = results.reduce((sum, r) => sum + r.annualKwh, 0)
 
   return { hourly, annualKwh, location: coords }
 }

--- a/src/lib/roofCapacity.test.ts
+++ b/src/lib/roofCapacity.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { estimateCapacityKw, estimatePanelCount, getSegmentPeakKw, DEFAULT_PANEL } from './roofCapacity'
+import type { RoofSegment } from '@/types'
+
+describe('estimateCapacityKw', () => {
+  it('computes capacity from usable area / panel area * wattage', () => {
+    // 10m x 6m roof, 85% usable = 51 m². Default panel area ~2.576 m².
+    // floor(51 / 2.576) = 19 panels * 440 Wp = 8.36 kW
+    const kw = estimateCapacityKw(10, 6, DEFAULT_PANEL)
+    expect(kw).toBeCloseTo(8.36, 1)
+  })
+
+  it('scales with usableFraction', () => {
+    const full = estimateCapacityKw(10, 6, DEFAULT_PANEL, 1)
+    const half = estimateCapacityKw(10, 6, DEFAULT_PANEL, 0.5)
+    expect(half).toBeLessThan(full)
+  })
+
+  it('returns 0 for a roof smaller than one panel', () => {
+    expect(estimateCapacityKw(1, 1, DEFAULT_PANEL)).toBe(0)
+  })
+
+  it('supports a custom panel spec', () => {
+    const smallPanel = { wattage: 300, widthM: 1, heightM: 1.6 }
+    const kw = estimateCapacityKw(10, 6, smallPanel)
+    // usable area 51 m², panel area 1.6 m² -> floor(31.875) = 31 panels * 300W
+    expect(kw).toBeCloseTo(9.3, 1)
+  })
+})
+
+describe('estimatePanelCount', () => {
+  it('matches the panel count implied by estimateCapacityKw', () => {
+    const count = estimatePanelCount(10, 6, DEFAULT_PANEL)
+    expect(count).toBe(19)
+    expect(estimateCapacityKw(10, 6, DEFAULT_PANEL)).toBeCloseTo((count * DEFAULT_PANEL.wattage) / 1000)
+  })
+})
+
+describe('getSegmentPeakKw', () => {
+  const base: RoofSegment = {
+    id: 's1',
+    inputMode: 'capacity',
+    tiltDeg: 35,
+    azimuthDeg: 0,
+    peakKw: 6,
+  }
+
+  it('returns stored peakKw in capacity mode', () => {
+    expect(getSegmentPeakKw(base)).toBe(6)
+  })
+
+  it('derives capacity from dimensions in dimensions mode', () => {
+    const seg: RoofSegment = {
+      ...base,
+      inputMode: 'dimensions',
+      roofWidthM: 10,
+      roofHeightM: 6,
+    }
+    expect(getSegmentPeakKw(seg)).toBeCloseTo(8.36, 1)
+  })
+
+  it('uses a custom panel spec when provided in dimensions mode', () => {
+    const seg: RoofSegment = {
+      ...base,
+      inputMode: 'dimensions',
+      roofWidthM: 10,
+      roofHeightM: 6,
+      panelWattage: 300,
+      panelWidthM: 1,
+      panelHeightM: 1.6,
+    }
+    expect(getSegmentPeakKw(seg)).toBeCloseTo(9.3, 1)
+  })
+
+  it('falls back to peakKw in dimensions mode when dimensions are missing', () => {
+    const seg: RoofSegment = { ...base, inputMode: 'dimensions', peakKw: 4 }
+    expect(getSegmentPeakKw(seg)).toBe(4)
+  })
+})

--- a/src/lib/roofCapacity.ts
+++ b/src/lib/roofCapacity.ts
@@ -1,0 +1,57 @@
+import type { RoofSegment } from '@/types'
+
+export interface PanelSpec {
+  wattage: number  // Wp per panel
+  widthM: number
+  heightM: number
+}
+
+// Typical modern residential module (~440 Wp, ~1.13m x 2.28m)
+export const DEFAULT_PANEL: PanelSpec = { wattage: 440, widthM: 1.13, heightM: 2.28 }
+
+/**
+ * Estimates installed peak capacity (kWp) for a roof area given a panel
+ * spec. This is an area-based approximation (usable area / panel area),
+ * not a rectangle-packing layout — usableFraction accounts for gaps,
+ * mounting clearance and obstructions like chimneys or vents.
+ */
+export function estimateCapacityKw(
+  roofWidthM: number,
+  roofHeightM: number,
+  panel: PanelSpec = DEFAULT_PANEL,
+  usableFraction = 0.85,
+): number {
+  const usableAreaM2 = roofWidthM * roofHeightM * usableFraction
+  const panelAreaM2 = panel.widthM * panel.heightM
+  const panelCount = Math.floor(usableAreaM2 / panelAreaM2)
+  return (panelCount * panel.wattage) / 1000
+}
+
+/** Number of panels implied by estimateCapacityKw's area calculation. */
+export function estimatePanelCount(
+  roofWidthM: number,
+  roofHeightM: number,
+  panel: PanelSpec = DEFAULT_PANEL,
+  usableFraction = 0.85,
+): number {
+  const usableAreaM2 = roofWidthM * roofHeightM * usableFraction
+  const panelAreaM2 = panel.widthM * panel.heightM
+  return Math.floor(usableAreaM2 / panelAreaM2)
+}
+
+/**
+ * Resolves a segment's effective peak capacity. In 'capacity' mode this is
+ * simply the stored peakKw; in 'dimensions' mode it's derived live from
+ * roof size + panel spec so there's no stale cached value to keep in sync.
+ */
+export function getSegmentPeakKw(segment: RoofSegment): number {
+  if (segment.inputMode === 'dimensions' && segment.roofWidthM && segment.roofHeightM) {
+    const panel: PanelSpec = {
+      wattage: segment.panelWattage ?? DEFAULT_PANEL.wattage,
+      widthM: segment.panelWidthM ?? DEFAULT_PANEL.widthM,
+      heightM: segment.panelHeightM ?? DEFAULT_PANEL.heightM,
+    }
+    return estimateCapacityKw(segment.roofWidthM, segment.roofHeightM, panel)
+  }
+  return segment.peakKw
+}

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useAppStore } from '@/store/appStore'
+import { useAppStore, MAX_SEGMENTS, defaultExistingSolarConfig } from '@/store/appStore'
 
 // Reset to defaults before every test to ensure isolation
 beforeEach(() => {
@@ -12,7 +12,10 @@ describe('appStore — initial state', () => {
     expect(s.address).toBe('')
     expect(s.postcode).toBe('')
     expect(s.coordinates).toBeNull()
-    expect(s.solarConfig).toEqual({ peakKw: 6, tiltDeg: 35, azimuthDeg: 0, systemLossPct: 14 })
+    expect(s.solarConfig.systemLossPct).toBe(14)
+    expect(s.solarConfig.segments).toHaveLength(1)
+    expect(s.solarConfig.segments[0]).toMatchObject({ inputMode: 'capacity', peakKw: 6, tiltDeg: 35, azimuthDeg: 0 })
+    expect(typeof s.solarConfig.segments[0].id).toBe('string')
     expect(s.consumption).toEqual({ source: 'manual', annualKwh: 5000 })
     expect(s.priceArea).toBe('DK2')
     expect(s.investmentDkk).toBe(60000)
@@ -48,21 +51,57 @@ describe('appStore — setters', () => {
     expect(useAppStore.getState().coordinates).toBeNull()
   })
 
-  it('setSolarConfig merges partial update', () => {
-    useAppStore.getState().setSolarConfig({ peakKw: 10 })
+  it('setSystemLossPct updates only the loss percentage', () => {
+    useAppStore.getState().setSystemLossPct(10)
     const c = useAppStore.getState().solarConfig
-    expect(c.peakKw).toBe(10)
-    expect(c.tiltDeg).toBe(35)     // unchanged
-    expect(c.azimuthDeg).toBe(0)   // unchanged
-    expect(c.systemLossPct).toBe(14) // unchanged
+    expect(c.systemLossPct).toBe(10)
+    expect(c.segments).toHaveLength(1)
   })
 
-  it('setSolarConfig handles multiple fields', () => {
-    useAppStore.getState().setSolarConfig({ tiltDeg: 20, azimuthDeg: 90 })
-    const c = useAppStore.getState().solarConfig
-    expect(c.tiltDeg).toBe(20)
-    expect(c.azimuthDeg).toBe(90)
-    expect(c.peakKw).toBe(6) // unchanged
+  it('updateSolarSegment merges a partial update into the matching segment', () => {
+    const id = useAppStore.getState().solarConfig.segments[0].id
+    useAppStore.getState().updateSolarSegment(id, { peakKw: 10 })
+    const seg = useAppStore.getState().solarConfig.segments[0]
+    expect(seg.peakKw).toBe(10)
+    expect(seg.tiltDeg).toBe(35)     // unchanged
+    expect(seg.azimuthDeg).toBe(0)   // unchanged
+  })
+
+  it('updateSolarSegment handles multiple fields', () => {
+    const id = useAppStore.getState().solarConfig.segments[0].id
+    useAppStore.getState().updateSolarSegment(id, { tiltDeg: 20, azimuthDeg: 90 })
+    const seg = useAppStore.getState().solarConfig.segments[0]
+    expect(seg.tiltDeg).toBe(20)
+    expect(seg.azimuthDeg).toBe(90)
+    expect(seg.peakKw).toBe(6) // unchanged
+  })
+
+  it('addSolarSegment appends a new segment, up to MAX_SEGMENTS', () => {
+    const { addSolarSegment } = useAppStore.getState()
+    addSolarSegment()
+    expect(useAppStore.getState().solarConfig.segments).toHaveLength(2)
+    addSolarSegment()
+    expect(useAppStore.getState().solarConfig.segments).toHaveLength(3)
+    addSolarSegment() // beyond MAX_SEGMENTS — no-op
+    expect(useAppStore.getState().solarConfig.segments).toHaveLength(MAX_SEGMENTS)
+  })
+
+  it('addSolarSegment assigns distinct ids and an east/west-leaning azimuth', () => {
+    useAppStore.getState().addSolarSegment()
+    const segments = useAppStore.getState().solarConfig.segments
+    expect(segments[1].id).not.toBe(segments[0].id)
+    expect(segments[1].azimuthDeg).toBe(-90)
+  })
+
+  it('removeSolarSegment removes the matching segment but never the last one', () => {
+    useAppStore.getState().addSolarSegment()
+    const secondId = useAppStore.getState().solarConfig.segments[1].id
+    useAppStore.getState().removeSolarSegment(secondId)
+    expect(useAppStore.getState().solarConfig.segments).toHaveLength(1)
+
+    const lastId = useAppStore.getState().solarConfig.segments[0].id
+    useAppStore.getState().removeSolarSegment(lastId)
+    expect(useAppStore.getState().solarConfig.segments).toHaveLength(1) // guarded — cannot remove the only segment
   })
 
   it('setInvestmentDkk', () => {
@@ -121,9 +160,28 @@ describe('appStore — setters', () => {
   })
 
   it('setExistingSolarConfig stores config', () => {
-    const cfg = { peakKw: 3, tiltDeg: 30, azimuthDeg: 0, systemLossPct: 14 }
+    const cfg = defaultExistingSolarConfig()
     useAppStore.getState().setExistingSolarConfig(cfg)
     expect(useAppStore.getState().existingSolarConfig).toEqual(cfg)
+  })
+
+  it('setExistingSystemLossPct is a no-op when existing solar is disabled', () => {
+    useAppStore.getState().setExistingSystemLossPct(8)
+    expect(useAppStore.getState().existingSolarConfig).toBeNull()
+  })
+
+  it('addExistingSegment / removeExistingSegment / updateExistingSegment operate on existingSolarConfig', () => {
+    useAppStore.getState().setExistingSolarConfig(defaultExistingSolarConfig())
+    useAppStore.getState().addExistingSegment()
+    expect(useAppStore.getState().existingSolarConfig?.segments).toHaveLength(2)
+
+    const id = useAppStore.getState().existingSolarConfig!.segments[0].id
+    useAppStore.getState().updateExistingSegment(id, { peakKw: 4 })
+    expect(useAppStore.getState().existingSolarConfig!.segments[0].peakKw).toBe(4)
+
+    const secondId = useAppStore.getState().existingSolarConfig!.segments[1].id
+    useAppStore.getState().removeExistingSegment(secondId)
+    expect(useAppStore.getState().existingSolarConfig?.segments).toHaveLength(1)
   })
 
   it('setConsumption merges partial update', () => {
@@ -151,9 +209,9 @@ describe('appStore — reset', () => {
     store.setFixedSpotDkk(0.60)
     store.setHeatpumpEnabled(true)
     store.setEvKmPerDay(80)
-    store.setSolarConfig({ peakKw: 12 })
+    store.updateSolarSegment(store.solarConfig.segments[0].id, { peakKw: 12 })
     store.setBatteryConfig({ capacityKwh: 10, maxChargeKw: 5, maxDischargeKw: 5, roundTripEfficiencyPct: 90, strategy: 'self-consumption' })
-    store.setExistingSolarConfig({ peakKw: 3, tiltDeg: 30, azimuthDeg: 0, systemLossPct: 14 })
+    store.setExistingSolarConfig(defaultExistingSolarConfig())
 
     store.reset()
 
@@ -165,7 +223,9 @@ describe('appStore — reset', () => {
     expect(s.fixedSpotDkk).toBeNull()
     expect(s.heatpumpEnabled).toBe(false)
     expect(s.evKmPerDay).toBeNull()
-    expect(s.solarConfig).toEqual({ peakKw: 6, tiltDeg: 35, azimuthDeg: 0, systemLossPct: 14 })
+    expect(s.solarConfig.systemLossPct).toBe(14)
+    expect(s.solarConfig.segments).toHaveLength(1)
+    expect(s.solarConfig.segments[0]).toMatchObject({ inputMode: 'capacity', peakKw: 6, tiltDeg: 35, azimuthDeg: 0 })
     expect(s.batteryConfig).toBeNull()
     expect(s.existingSolarConfig).toBeNull()
     expect(s.pvgisData).toBeNull()

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware'
 import type {
   BatteryConfig,
   Coordinates,
+  RoofSegment,
   SolarConfig,
   ConsumptionData,
   HourlyPrice,
@@ -10,6 +11,60 @@ import type {
   SimulationResult,
 } from '@/types'
 import type { PriceArea } from '@/lib/energidataservice'
+
+export const MAX_SEGMENTS = 3
+
+function makeSegment(overrides: Partial<RoofSegment> = {}): RoofSegment {
+  return {
+    id: crypto.randomUUID(),
+    inputMode: 'capacity',
+    peakKw: 3,
+    tiltDeg: 35,
+    azimuthDeg: 0,
+    ...overrides,
+  }
+}
+
+// Azimuth suggested for the next segment added — nudges toward the
+// east/west split roof that motivated multi-segment support (issue #41).
+function nextSegmentAzimuth(existingCount: number): number {
+  return existingCount === 1 ? -90 : 90
+}
+
+function defaultSolarConfig(): SolarConfig {
+  return { systemLossPct: 14, segments: [makeSegment({ peakKw: 6, azimuthDeg: 0 })] }
+}
+
+function defaultExistingSolarConfig(): SolarConfig {
+  return { systemLossPct: 5, segments: [makeSegment({ peakKw: 6, azimuthDeg: 0 })] }
+}
+
+// --- Persisted-state migration (v1 flat SolarConfig -> v2 segments array) ---
+
+interface LegacyFlatSolarConfig {
+  peakKw: number
+  tiltDeg: number
+  azimuthDeg: number
+  systemLossPct: number
+}
+
+function isLegacyFlatSolarConfig(cfg: unknown): cfg is LegacyFlatSolarConfig {
+  return (
+    typeof cfg === 'object' && cfg !== null &&
+    'peakKw' in cfg && 'tiltDeg' in cfg && 'azimuthDeg' in cfg && 'systemLossPct' in cfg &&
+    !('segments' in cfg)
+  )
+}
+
+function migrateSolarConfig(cfg: unknown): unknown {
+  if (isLegacyFlatSolarConfig(cfg)) {
+    return {
+      systemLossPct: cfg.systemLossPct,
+      segments: [makeSegment({ peakKw: cfg.peakKw, tiltDeg: cfg.tiltDeg, azimuthDeg: cfg.azimuthDeg })],
+    }
+  }
+  return cfg
+}
 
 interface AppState {
   // User inputs (persisted in localStorage)
@@ -38,7 +93,10 @@ interface AppState {
   setAddress: (address: string) => void
   setPostcode: (postcode: string) => void
   setCoordinates: (coords: Coordinates | null) => void
-  setSolarConfig: (config: Partial<SolarConfig>) => void
+  setSystemLossPct: (pct: number) => void
+  addSolarSegment: () => void
+  removeSolarSegment: (id: string) => void
+  updateSolarSegment: (id: string, partial: Partial<RoofSegment>) => void
   setConsumption: (consumption: Partial<ConsumptionData> & { hourlyKwh?: number[] | undefined }) => void
   setPriceArea: (area: PriceArea) => void
   setInvestmentDkk: (dkk: number) => void
@@ -48,19 +106,16 @@ interface AppState {
   setBatteryConfig: (config: BatteryConfig | null) => void
   setDataYear: (year: number) => void
   setExistingSolarConfig: (config: SolarConfig | null) => void
+  setExistingSystemLossPct: (pct: number) => void
+  addExistingSegment: () => void
+  removeExistingSegment: (id: string) => void
+  updateExistingSegment: (id: string, partial: Partial<RoofSegment>) => void
   setPVGISData: (data: PVGISData | null) => void
   setSimulationResult: (result: SimulationResult | null) => void
   setHourlyPrices: (prices: HourlyPrice[] | null) => void
   setEloverblikDsoGln: (gln: string | null) => void
   setTheme: (theme: 'light' | 'dark' | 'system') => void
   reset: () => void
-}
-
-const DEFAULT_SOLAR_CONFIG: SolarConfig = {
-  peakKw: 6,
-  tiltDeg: 35,
-  azimuthDeg: 0,   // south-facing
-  systemLossPct: 14,
 }
 
 const DEFAULT_CONSUMPTION: ConsumptionData = {
@@ -74,7 +129,7 @@ export const useAppStore = create<AppState>()(
       address: '',
       postcode: '',
       coordinates: null,
-      solarConfig: DEFAULT_SOLAR_CONFIG,
+      solarConfig: defaultSolarConfig(),
       consumption: DEFAULT_CONSUMPTION,
       priceArea: 'DK2',
       investmentDkk: 60000,
@@ -93,8 +148,37 @@ export const useAppStore = create<AppState>()(
       setAddress: (address) => set({ address }),
       setPostcode: (postcode) => set({ postcode }),
       setCoordinates: (coordinates) => set({ coordinates }),
-      setSolarConfig: (config) =>
-        set((s) => ({ solarConfig: { ...s.solarConfig, ...config } })),
+
+      setSystemLossPct: (systemLossPct) =>
+        set((s) => ({ solarConfig: { ...s.solarConfig, systemLossPct } })),
+      addSolarSegment: () =>
+        set((s) => {
+          if (s.solarConfig.segments.length >= MAX_SEGMENTS) return s
+          const azimuthDeg = nextSegmentAzimuth(s.solarConfig.segments.length)
+          return {
+            solarConfig: {
+              ...s.solarConfig,
+              segments: [...s.solarConfig.segments, makeSegment({ azimuthDeg })],
+            },
+          }
+        }),
+      removeSolarSegment: (id) =>
+        set((s) => ({
+          solarConfig: {
+            ...s.solarConfig,
+            segments: s.solarConfig.segments.length > 1
+              ? s.solarConfig.segments.filter((seg) => seg.id !== id)
+              : s.solarConfig.segments,
+          },
+        })),
+      updateSolarSegment: (id, partial) =>
+        set((s) => ({
+          solarConfig: {
+            ...s.solarConfig,
+            segments: s.solarConfig.segments.map((seg) => (seg.id === id ? { ...seg, ...partial } : seg)),
+          },
+        })),
+
       setConsumption: (consumption) =>
         set((s) => ({ consumption: { ...s.consumption, ...consumption } })),
       setPriceArea: (priceArea) => set({ priceArea }),
@@ -104,7 +188,46 @@ export const useAppStore = create<AppState>()(
       setEvKmPerDay: (evKmPerDay) => set({ evKmPerDay }),
       setBatteryConfig: (batteryConfig) => set({ batteryConfig }),
       setDataYear: (dataYear) => set({ dataYear }),
+
       setExistingSolarConfig: (existingSolarConfig) => set({ existingSolarConfig }),
+      setExistingSystemLossPct: (systemLossPct) =>
+        set((s) => (s.existingSolarConfig
+          ? { existingSolarConfig: { ...s.existingSolarConfig, systemLossPct } }
+          : s)),
+      addExistingSegment: () =>
+        set((s) => {
+          if (!s.existingSolarConfig || s.existingSolarConfig.segments.length >= MAX_SEGMENTS) return s
+          const azimuthDeg = nextSegmentAzimuth(s.existingSolarConfig.segments.length)
+          return {
+            existingSolarConfig: {
+              ...s.existingSolarConfig,
+              segments: [...s.existingSolarConfig.segments, makeSegment({ azimuthDeg })],
+            },
+          }
+        }),
+      removeExistingSegment: (id) =>
+        set((s) => {
+          if (!s.existingSolarConfig) return s
+          return {
+            existingSolarConfig: {
+              ...s.existingSolarConfig,
+              segments: s.existingSolarConfig.segments.length > 1
+                ? s.existingSolarConfig.segments.filter((seg) => seg.id !== id)
+                : s.existingSolarConfig.segments,
+            },
+          }
+        }),
+      updateExistingSegment: (id, partial) =>
+        set((s) => {
+          if (!s.existingSolarConfig) return s
+          return {
+            existingSolarConfig: {
+              ...s.existingSolarConfig,
+              segments: s.existingSolarConfig.segments.map((seg) => (seg.id === id ? { ...seg, ...partial } : seg)),
+            },
+          }
+        }),
+
       setPVGISData: (pvgisData) => set({ pvgisData }),
       setSimulationResult: (simulationResult) => set({ simulationResult }),
       setHourlyPrices: (hourlyPrices) => set({ hourlyPrices }),
@@ -115,7 +238,7 @@ export const useAppStore = create<AppState>()(
           address: '',
           postcode: '',
           coordinates: null,
-          solarConfig: DEFAULT_SOLAR_CONFIG,
+          solarConfig: defaultSolarConfig(),
           consumption: DEFAULT_CONSUMPTION,
           priceArea: 'DK2',
           investmentDkk: 60000,
@@ -133,6 +256,16 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'energitjek-state',
+      version: 2,
+      migrate: (persisted, version) => {
+        if (version < 2 && persisted && typeof persisted === 'object') {
+          const state = persisted as Record<string, unknown>
+          if ('solarConfig' in state) state.solarConfig = migrateSolarConfig(state.solarConfig)
+          if ('existingSolarConfig' in state) state.existingSolarConfig = migrateSolarConfig(state.existingSolarConfig)
+          return state
+        }
+        return persisted
+      },
       // Only persist user inputs, not computed results
       partialize: (s) => ({
         address: s.address,
@@ -157,3 +290,5 @@ export const useAppStore = create<AppState>()(
     },
   ),
 )
+
+export { defaultExistingSolarConfig }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,28 @@
 // --- Solar system configuration ---
+export type SegmentInputMode = 'capacity' | 'dimensions'
+
+/**
+ * One roof face / segment of a PV system (e.g. an east-facing and a
+ * west-facing half of a split roof). PVGIS is queried per segment and the
+ * hourly production arrays are summed — see fetchPVGISDataForSegments.
+ */
+export interface RoofSegment {
+  id: string
+  inputMode: SegmentInputMode
+  tiltDeg: number         // Panel tilt angle (0 = flat, 90 = vertical)
+  azimuthDeg: number      // Azimuth (0 = south, -90 = east, 90 = west)
+  peakKw: number          // Installed peak capacity in kWp — used when inputMode === 'capacity'
+  // Dimensions mode — capacity is derived, see getSegmentPeakKw()
+  roofWidthM?: number
+  roofHeightM?: number
+  panelWattage?: number   // Wp per panel; defaults to DEFAULT_PANEL.wattage
+  panelWidthM?: number
+  panelHeightM?: number
+}
+
 export interface SolarConfig {
-  peakKw: number         // Installed peak capacity in kWp
-  tiltDeg: number        // Panel tilt angle (0 = flat, 90 = vertical)
-  azimuthDeg: number     // Azimuth (0 = south, -90 = east, 90 = west)
-  systemLossPct: number  // Total system losses (%), typically 14
+  systemLossPct: number   // Total system losses (%), typically 14
+  segments: RoofSegment[] // 1–3 roof segments
 }
 
 // --- Address & location ---


### PR DESCRIPTION
## Summary

Closes #41. Adds support for 1–3 roof segments per solar system, each with its own capacity, tilt and azimuth — so users with e.g. an east/west split roof can model it accurately.

- **Segment-count selector** (1/2/3) on both the planned system and "Eksisterende anlæg" (existing solar), reusing a shared `RoofSegmentCard` component.
- **PVGIS is called once per segment** and hourly production arrays are summed (`fetchPVGISDataForSegments`); total system size and combined production feed into the simulation as before.
- **Two ways to set a segment's capacity**, selectable per segment: direct kWp input, or derived live from roof width/height + a configurable panel spec (wattage, panel size) — addresses the alternative approach suggested in the issue thread.
- Tilt/orientation is a per-segment collapsible (matching the existing "Panelspecifikationer" pattern), so it's reachable regardless of segment count or Standard/Avanceret mode.
- `SolarConfig`'s shape changed from flat `peakKw/tiltDeg/azimuthDeg` to a `segments` array; existing users' `localStorage` state is migrated automatically via a zustand `persist` `migrate()`.
- Updated the "Solproduktion — PVGIS" section of the Metode page to explain multi-segment summation and the two capacity-input methods.

## Test plan

- [x] `npx tsc -b`, `npm run lint`, `npm test` (159/159 unit tests) all pass
- [x] `npm run build` succeeds
- [x] Manually verified in a running dev server against real PVGIS/Nominatim/Energidataservice: adding 2nd/3rd segments, switching capacity ↔ dimensions mode, multiple direction arrows on the map, total kWp and production updating correctly, and the existing-solar segment selector operating independently from the planned system's
- [x] Confirmed the single-segment default still renders identically to before (`6 kWp · Syd · 35° hældning`), so existing behavior for current users is unchanged
- [ ] `npm run test:e2e` — not run against this PR; the e2e suite fails independently of this change on a clean `main` checkout (missing input-mode toggle), tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)